### PR TITLE
Add .shed.yml file to each repository.

### DIFF
--- a/data_managers/data_manager_bwa_index_builder/.shed.yml
+++ b/data_managers/data_manager_bwa_index_builder/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/data_manager_bwa_index_builder
+owner: devteam
+name: data_manager_bwa_index_builder
+    

--- a/data_managers/data_manager_fetch_genome_all_fasta/.shed.yml
+++ b/data_managers/data_manager_fetch_genome_all_fasta/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/data_manager_fetch_genome_all_fasta
+owner: devteam
+name: data_manager_fetch_genome_all_fasta
+    

--- a/data_managers/data_manager_gatk_picard_index_builder/.shed.yml
+++ b/data_managers/data_manager_gatk_picard_index_builder/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/data_manager_gatk_picard_index_builder
+owner: devteam
+name: data_manager_gatk_picard_index_builder
+    

--- a/data_managers/data_manager_sam_fasta_index_builder/.shed.yml
+++ b/data_managers/data_manager_sam_fasta_index_builder/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/data_manager_sam_fasta_index_builder
+owner: devteam
+name: data_manager_sam_fasta_index_builder
+    

--- a/datatypes/emboss_datatypes/.shed.yml
+++ b/datatypes/emboss_datatypes/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/emboss_datatypes
+owner: devteam
+name: emboss_datatypes
+    

--- a/packages/freebayes_0_9_14_8a407cf5f4/.shed.yml
+++ b/packages/freebayes_0_9_14_8a407cf5f4/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/freebayes_0_9_14_8a407cf5f4
+owner: devteam
+name: freebayes_0_9_14_8a407cf5f4
+    

--- a/packages/package_bioc_hilbertvis_1_18_0/.shed.yml
+++ b/packages/package_bioc_hilbertvis_1_18_0/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_bioc_hilbertvis_1_18_0
+owner: devteam
+name: package_bioc_hilbertvis_1_18_0
+    

--- a/packages/package_bioc_qvalue_1_34_0/.shed.yml
+++ b/packages/package_bioc_qvalue_1_34_0/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_bioc_qvalue_1_34_0
+owner: devteam
+name: package_bioc_qvalue_1_34_0
+    

--- a/packages/package_blast_plus_2_2_26/.shed.yml
+++ b/packages/package_blast_plus_2_2_26/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_blast_plus_2_2_26
+owner: devteam
+name: package_blast_plus_2_2_26
+    

--- a/packages/package_bowtie2_2_1_0/.shed.yml
+++ b/packages/package_bowtie2_2_1_0/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_bowtie2_2_1_0
+owner: devteam
+name: package_bowtie2_2_1_0
+    

--- a/packages/package_bowtie_0_12_7/.shed.yml
+++ b/packages/package_bowtie_0_12_7/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_bowtie_0_12_7
+owner: devteam
+name: package_bowtie_0_12_7
+    

--- a/packages/package_bwa_0_5_9/.shed.yml
+++ b/packages/package_bwa_0_5_9/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_bwa_0_5_9
+owner: devteam
+name: package_bwa_0_5_9
+    

--- a/packages/package_bwa_0_6_2/.shed.yml
+++ b/packages/package_bwa_0_6_2/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_bwa_0_6_2
+owner: devteam
+name: package_bwa_0_6_2
+    

--- a/packages/package_bx_python_0_7/.shed.yml
+++ b/packages/package_bx_python_0_7/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_bx_python_0_7
+owner: devteam
+name: package_bx_python_0_7
+    

--- a/packages/package_cairo_1_12_14/.shed.yml
+++ b/packages/package_cairo_1_12_14/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_cairo_1_12_14
+owner: devteam
+name: package_cairo_1_12_14
+    

--- a/packages/package_ccat_3_0/.shed.yml
+++ b/packages/package_ccat_3_0/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_ccat_3_0
+owner: devteam
+name: package_ccat_3_0
+    

--- a/packages/package_clustalw_2_1/.shed.yml
+++ b/packages/package_clustalw_2_1/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_clustalw_2_1
+owner: devteam
+name: package_clustalw_2_1
+    

--- a/packages/package_cran_kernlab_0_1_4/.shed.yml
+++ b/packages/package_cran_kernlab_0_1_4/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_cran_kernlab_0_1_4
+owner: devteam
+name: package_cran_kernlab_0_1_4
+    

--- a/packages/package_cran_yacca_1_0/.shed.yml
+++ b/packages/package_cran_yacca_1_0/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_cran_yacca_1_0
+owner: devteam
+name: package_cran_yacca_1_0
+    

--- a/packages/package_cufflinks_2_1_1/.shed.yml
+++ b/packages/package_cufflinks_2_1_1/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_cufflinks_2_1_1
+owner: devteam
+name: package_cufflinks_2_1_1
+    

--- a/packages/package_eigen_3_2_0/.shed.yml
+++ b/packages/package_eigen_3_2_0/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_eigen_3_2_0
+owner: devteam
+name: package_eigen_3_2_0
+    

--- a/packages/package_emboss_5_0_0/.shed.yml
+++ b/packages/package_emboss_5_0_0/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_emboss_5_0_0
+owner: devteam
+name: package_emboss_5_0_0
+    

--- a/packages/package_express_1_1_1/.shed.yml
+++ b/packages/package_express_1_1_1/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_express_1_1_1
+owner: devteam
+name: package_express_1_1_1
+    

--- a/packages/package_fastqc_0_10_1/.shed.yml
+++ b/packages/package_fastqc_0_10_1/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_fastqc_0_10_1
+owner: devteam
+name: package_fastqc_0_10_1
+    

--- a/packages/package_fastx_toolkit_0_0_13/.shed.yml
+++ b/packages/package_fastx_toolkit_0_0_13/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_fastx_toolkit_0_0_13
+owner: devteam
+name: package_fastx_toolkit_0_0_13
+    

--- a/packages/package_fontconfig_2_11_1/.shed.yml
+++ b/packages/package_fontconfig_2_11_1/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_fontconfig_2_11_1
+owner: devteam
+name: package_fontconfig_2_11_1
+    

--- a/packages/package_freebayes_0_9_6_9608597d/.shed.yml
+++ b/packages/package_freebayes_0_9_6_9608597d/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_freebayes_0_9_6_9608597d
+owner: devteam
+name: package_freebayes_0_9_6_9608597d
+    

--- a/packages/package_freetype_2_5_2/.shed.yml
+++ b/packages/package_freetype_2_5_2/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_freetype_2_5_2
+owner: devteam
+name: package_freetype_2_5_2
+    

--- a/packages/package_galaxy_ops_1_0_0/.shed.yml
+++ b/packages/package_galaxy_ops_1_0_0/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_galaxy_ops_1_0_0
+owner: devteam
+name: package_galaxy_ops_1_0_0
+    

--- a/packages/package_galaxy_utils_1_0/.shed.yml
+++ b/packages/package_galaxy_utils_1_0/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_galaxy_utils_1_0
+owner: devteam
+name: package_galaxy_utils_1_0
+    

--- a/packages/package_gatk_1_4/.shed.yml
+++ b/packages/package_gatk_1_4/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_gatk_1_4
+owner: devteam
+name: package_gatk_1_4
+    

--- a/packages/package_ghostscript_9_10/.shed.yml
+++ b/packages/package_ghostscript_9_10/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_ghostscript_9_10
+owner: devteam
+name: package_ghostscript_9_10
+    

--- a/packages/package_inputproto_2_2/.shed.yml
+++ b/packages/package_inputproto_2_2/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_inputproto_2_2
+owner: devteam
+name: package_inputproto_2_2
+    

--- a/packages/package_kbproto_1_0_6/.shed.yml
+++ b/packages/package_kbproto_1_0_6/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_kbproto_1_0_6
+owner: devteam
+name: package_kbproto_1_0_6
+    

--- a/packages/package_lastz_1_02_00/.shed.yml
+++ b/packages/package_lastz_1_02_00/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_lastz_1_02_00
+owner: devteam
+name: package_lastz_1_02_00
+    

--- a/packages/package_libgd_2_1_0/.shed.yml
+++ b/packages/package_libgd_2_1_0/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_libgd_2_1_0
+owner: devteam
+name: package_libgd_2_1_0
+    

--- a/packages/package_libgtextutils_0_6/.shed.yml
+++ b/packages/package_libgtextutils_0_6/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_libgtextutils_0_6
+owner: devteam
+name: package_libgtextutils_0_6
+    

--- a/packages/package_libpng_1_6_7/.shed.yml
+++ b/packages/package_libpng_1_6_7/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_libpng_1_6_7
+owner: devteam
+name: package_libpng_1_6_7
+    

--- a/packages/package_libpthread_stubs_0_3/.shed.yml
+++ b/packages/package_libpthread_stubs_0_3/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_libpthread_stubs_0_3
+owner: devteam
+name: package_libpthread_stubs_0_3
+    

--- a/packages/package_libx11_1_5_0/.shed.yml
+++ b/packages/package_libx11_1_5_0/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_libx11_1_5_0
+owner: devteam
+name: package_libx11_1_5_0
+    

--- a/packages/package_libxau_1_0_8/.shed.yml
+++ b/packages/package_libxau_1_0_8/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_libxau_1_0_8
+owner: devteam
+name: package_libxau_1_0_8
+    

--- a/packages/package_libxcb_1_9_1/.shed.yml
+++ b/packages/package_libxcb_1_9_1/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_libxcb_1_9_1
+owner: devteam
+name: package_libxcb_1_9_1
+    

--- a/packages/package_libxcb_proto_1_8/.shed.yml
+++ b/packages/package_libxcb_proto_1_8/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_libxcb_proto_1_8
+owner: devteam
+name: package_libxcb_proto_1_8
+    

--- a/packages/package_libxext_proto_7_2_1/.shed.yml
+++ b/packages/package_libxext_proto_7_2_1/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_libxext_proto_7_2_1
+owner: devteam
+name: package_libxext_proto_7_2_1
+    

--- a/packages/package_libxml2_2_9_1/.shed.yml
+++ b/packages/package_libxml2_2_9_1/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_libxml2_2_9_1
+owner: devteam
+name: package_libxml2_2_9_1
+    

--- a/packages/package_libxproto_7_0_23/.shed.yml
+++ b/packages/package_libxproto_7_0_23/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_libxproto_7_0_23
+owner: devteam
+name: package_libxproto_7_0_23
+    

--- a/packages/package_libxslt_1_1_28/.shed.yml
+++ b/packages/package_libxslt_1_1_28/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_libxslt_1_1_28
+owner: devteam
+name: package_libxslt_1_1_28
+    

--- a/packages/package_libxtrans_1_2_7/.shed.yml
+++ b/packages/package_libxtrans_1_2_7/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_libxtrans_1_2_7
+owner: devteam
+name: package_libxtrans_1_2_7
+    

--- a/packages/package_macs_1_3_7_1/.shed.yml
+++ b/packages/package_macs_1_3_7_1/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_macs_1_3_7_1
+owner: devteam
+name: package_macs_1_3_7_1
+    

--- a/packages/package_mine_1_0_1/.shed.yml
+++ b/packages/package_mine_1_0_1/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_mine_1_0_1
+owner: devteam
+name: package_mine_1_0_1
+    

--- a/packages/package_numpy_1_7/.shed.yml
+++ b/packages/package_numpy_1_7/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_numpy_1_7
+owner: devteam
+name: package_numpy_1_7
+    

--- a/packages/package_picard_1_56_0/.shed.yml
+++ b/packages/package_picard_1_56_0/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_picard_1_56_0
+owner: devteam
+name: package_picard_1_56_0
+    

--- a/packages/package_pixman_0_32_4/.shed.yml
+++ b/packages/package_pixman_0_32_4/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_pixman_0_32_4
+owner: devteam
+name: package_pixman_0_32_4
+    

--- a/packages/package_r_2_11_0/.shed.yml
+++ b/packages/package_r_2_11_0/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_r_2_11_0
+owner: devteam
+name: package_r_2_11_0
+    

--- a/packages/package_r_2_15_0/.shed.yml
+++ b/packages/package_r_2_15_0/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_r_2_15_0
+owner: devteam
+name: package_r_2_15_0
+    

--- a/packages/package_readline_6_2/.shed.yml
+++ b/packages/package_readline_6_2/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_readline_6_2
+owner: devteam
+name: package_readline_6_2
+    

--- a/packages/package_rmap_2_05/.shed.yml
+++ b/packages/package_rmap_2_05/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_rmap_2_05
+owner: devteam
+name: package_rmap_2_05
+    

--- a/packages/package_rpy_1_0_3/.shed.yml
+++ b/packages/package_rpy_1_0_3/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_rpy_1_0_3
+owner: devteam
+name: package_rpy_1_0_3
+    

--- a/packages/package_samtools_0_1_16/.shed.yml
+++ b/packages/package_samtools_0_1_16/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_samtools_0_1_16
+owner: devteam
+name: package_samtools_0_1_16
+    

--- a/packages/package_samtools_0_1_18/.shed.yml
+++ b/packages/package_samtools_0_1_18/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_samtools_0_1_18
+owner: devteam
+name: package_samtools_0_1_18
+    

--- a/packages/package_samtools_0_1_19/.shed.yml
+++ b/packages/package_samtools_0_1_19/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_samtools_0_1_19
+owner: devteam
+name: package_samtools_0_1_19
+    

--- a/packages/package_sicer_1_1/.shed.yml
+++ b/packages/package_sicer_1_1/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_sicer_1_1
+owner: devteam
+name: package_sicer_1_1
+    

--- a/packages/package_sputnik_1_0/.shed.yml
+++ b/packages/package_sputnik_1_0/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_sputnik_1_0
+owner: devteam
+name: package_sputnik_1_0
+    

--- a/packages/package_taxonomy_1_0_0/.shed.yml
+++ b/packages/package_taxonomy_1_0_0/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_taxonomy_1_0_0
+owner: devteam
+name: package_taxonomy_1_0_0
+    

--- a/packages/package_tophat2_2_0_9/.shed.yml
+++ b/packages/package_tophat2_2_0_9/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_tophat2_2_0_9
+owner: devteam
+name: package_tophat2_2_0_9
+    

--- a/packages/package_tophat_1_4_0/.shed.yml
+++ b/packages/package_tophat_1_4_0/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_tophat_1_4_0
+owner: devteam
+name: package_tophat_1_4_0
+    

--- a/packages/package_vcftools_0_1_11/.shed.yml
+++ b/packages/package_vcftools_0_1_11/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_vcftools_0_1_11
+owner: devteam
+name: package_vcftools_0_1_11
+    

--- a/packages/package_weblogo_3_3/.shed.yml
+++ b/packages/package_weblogo_3_3/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_weblogo_3_3
+owner: devteam
+name: package_weblogo_3_3
+    

--- a/packages/package_xorg_macros_1_17_1/.shed.yml
+++ b/packages/package_xorg_macros_1_17_1/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/package_xorg_macros_1_17_1
+owner: devteam
+name: package_xorg_macros_1_17_1
+    

--- a/suites/all_cufflinks_tool_suite/.shed.yml
+++ b/suites/all_cufflinks_tool_suite/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/all_cufflinks_tool_suite
+owner: devteam
+name: all_cufflinks_tool_suite
+    

--- a/suites/all_vcftools/.shed.yml
+++ b/suites/all_vcftools/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/all_vcftools
+owner: devteam
+name: all_vcftools
+    

--- a/suites/suite_fastx_toolkit_0_0_13/.shed.yml
+++ b/suites/suite_fastx_toolkit_0_0_13/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/suite_fastx_toolkit_0_0_13
+owner: devteam
+name: suite_fastx_toolkit_0_0_13
+    

--- a/suites/suite_gatk_1_4/.shed.yml
+++ b/suites/suite_gatk_1_4/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/suite_gatk_1_4
+owner: devteam
+name: suite_gatk_1_4
+    

--- a/suites/suite_gops_1_0/.shed.yml
+++ b/suites/suite_gops_1_0/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/suite_gops_1_0
+owner: devteam
+name: suite_gops_1_0
+    

--- a/suites/suite_samtools_0_1_18/.shed.yml
+++ b/suites/suite_samtools_0_1_18/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/suite_samtools_0_1_18
+owner: devteam
+name: suite_samtools_0_1_18
+    

--- a/suites/suite_samtools_0_1_19/.shed.yml
+++ b/suites/suite_samtools_0_1_19/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/suite_samtools_0_1_19
+owner: devteam
+name: suite_samtools_0_1_19
+    

--- a/tool_collections/cufflinks/cuffcompare/.shed.yml
+++ b/tool_collections/cufflinks/cuffcompare/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/cuffcompare
+owner: devteam
+name: cuffcompare
+    

--- a/tool_collections/cufflinks/cuffdiff/.shed.yml
+++ b/tool_collections/cufflinks/cuffdiff/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/cuffdiff
+owner: devteam
+name: cuffdiff
+    

--- a/tool_collections/cufflinks/cufflinks/.shed.yml
+++ b/tool_collections/cufflinks/cufflinks/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/cufflinks
+owner: devteam
+name: cufflinks
+    

--- a/tool_collections/cufflinks/cuffmerge/.shed.yml
+++ b/tool_collections/cufflinks/cuffmerge/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/cuffmerge
+owner: devteam
+name: cuffmerge
+    

--- a/tool_collections/fastx_toolkit/fasta_clipping_histogram/.shed.yml
+++ b/tool_collections/fastx_toolkit/fasta_clipping_histogram/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fasta_clipping_histogram
+owner: devteam
+name: fasta_clipping_histogram
+    

--- a/tool_collections/fastx_toolkit/fasta_formatter/.shed.yml
+++ b/tool_collections/fastx_toolkit/fasta_formatter/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fasta_formatter
+owner: devteam
+name: fasta_formatter
+    

--- a/tool_collections/fastx_toolkit/fasta_nucleotide_changer/.shed.yml
+++ b/tool_collections/fastx_toolkit/fasta_nucleotide_changer/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fasta_nucleotide_changer
+owner: devteam
+name: fasta_nucleotide_changer
+    

--- a/tool_collections/fastx_toolkit/fastq_quality_boxplot/.shed.yml
+++ b/tool_collections/fastx_toolkit/fastq_quality_boxplot/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastq_quality_boxplot
+owner: devteam
+name: fastq_quality_boxplot
+    

--- a/tool_collections/fastx_toolkit/fastq_quality_converter/.shed.yml
+++ b/tool_collections/fastx_toolkit/fastq_quality_converter/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastq_quality_converter
+owner: devteam
+name: fastq_quality_converter
+    

--- a/tool_collections/fastx_toolkit/fastq_quality_filter/.shed.yml
+++ b/tool_collections/fastx_toolkit/fastq_quality_filter/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastq_quality_filter
+owner: devteam
+name: fastq_quality_filter
+    

--- a/tool_collections/fastx_toolkit/fastq_to_fasta/.shed.yml
+++ b/tool_collections/fastx_toolkit/fastq_to_fasta/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastq_to_fasta
+owner: devteam
+name: fastq_to_fasta
+    

--- a/tool_collections/fastx_toolkit/fastx_artifacts_filter/.shed.yml
+++ b/tool_collections/fastx_toolkit/fastx_artifacts_filter/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastx_artifacts_filter
+owner: devteam
+name: fastx_artifacts_filter
+    

--- a/tool_collections/fastx_toolkit/fastx_barcode_splitter/.shed.yml
+++ b/tool_collections/fastx_toolkit/fastx_barcode_splitter/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastx_barcode_splitter
+owner: devteam
+name: fastx_barcode_splitter
+    

--- a/tool_collections/fastx_toolkit/fastx_clipper/.shed.yml
+++ b/tool_collections/fastx_toolkit/fastx_clipper/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastx_clipper
+owner: devteam
+name: fastx_clipper
+    

--- a/tool_collections/fastx_toolkit/fastx_collapser/.shed.yml
+++ b/tool_collections/fastx_toolkit/fastx_collapser/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastx_collapser
+owner: devteam
+name: fastx_collapser
+    

--- a/tool_collections/fastx_toolkit/fastx_nucleotides_distribution/.shed.yml
+++ b/tool_collections/fastx_toolkit/fastx_nucleotides_distribution/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastx_nucleotides_distribution
+owner: devteam
+name: fastx_nucleotides_distribution
+    

--- a/tool_collections/fastx_toolkit/fastx_quality_statistics/.shed.yml
+++ b/tool_collections/fastx_toolkit/fastx_quality_statistics/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastx_quality_statistics
+owner: devteam
+name: fastx_quality_statistics
+    

--- a/tool_collections/fastx_toolkit/fastx_renamer/.shed.yml
+++ b/tool_collections/fastx_toolkit/fastx_renamer/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastx_renamer
+owner: devteam
+name: fastx_renamer
+    

--- a/tool_collections/fastx_toolkit/fastx_reverse_complement/.shed.yml
+++ b/tool_collections/fastx_toolkit/fastx_reverse_complement/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastx_reverse_complement
+owner: devteam
+name: fastx_reverse_complement
+    

--- a/tool_collections/fastx_toolkit/fastx_trimmer/.shed.yml
+++ b/tool_collections/fastx_toolkit/fastx_trimmer/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastx_trimmer
+owner: devteam
+name: fastx_trimmer
+    

--- a/tool_collections/galaxy_sequence_utils/fastq_combiner/.shed.yml
+++ b/tool_collections/galaxy_sequence_utils/fastq_combiner/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastq_combiner
+owner: devteam
+name: fastq_combiner
+    

--- a/tool_collections/galaxy_sequence_utils/fastq_filter/.shed.yml
+++ b/tool_collections/galaxy_sequence_utils/fastq_filter/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastq_filter
+owner: devteam
+name: fastq_filter
+    

--- a/tool_collections/galaxy_sequence_utils/fastq_groomer/.shed.yml
+++ b/tool_collections/galaxy_sequence_utils/fastq_groomer/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastq_groomer
+owner: devteam
+name: fastq_groomer
+    

--- a/tool_collections/galaxy_sequence_utils/fastq_manipulation/.shed.yml
+++ b/tool_collections/galaxy_sequence_utils/fastq_manipulation/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastq_manipulation
+owner: devteam
+name: fastq_manipulation
+    

--- a/tool_collections/galaxy_sequence_utils/fastq_masker_by_quality/.shed.yml
+++ b/tool_collections/galaxy_sequence_utils/fastq_masker_by_quality/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastq_masker_by_quality
+owner: devteam
+name: fastq_masker_by_quality
+    

--- a/tool_collections/galaxy_sequence_utils/fastq_paired_end_deinterlacer/.shed.yml
+++ b/tool_collections/galaxy_sequence_utils/fastq_paired_end_deinterlacer/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastq_paired_end_deinterlacer
+owner: devteam
+name: fastq_paired_end_deinterlacer
+    

--- a/tool_collections/galaxy_sequence_utils/fastq_paired_end_interlacer/.shed.yml
+++ b/tool_collections/galaxy_sequence_utils/fastq_paired_end_interlacer/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastq_paired_end_interlacer
+owner: devteam
+name: fastq_paired_end_interlacer
+    

--- a/tool_collections/galaxy_sequence_utils/fastq_paired_end_joiner/.shed.yml
+++ b/tool_collections/galaxy_sequence_utils/fastq_paired_end_joiner/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastq_paired_end_joiner
+owner: devteam
+name: fastq_paired_end_joiner
+    

--- a/tool_collections/galaxy_sequence_utils/fastq_paired_end_splitter/.shed.yml
+++ b/tool_collections/galaxy_sequence_utils/fastq_paired_end_splitter/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastq_paired_end_splitter
+owner: devteam
+name: fastq_paired_end_splitter
+    

--- a/tool_collections/galaxy_sequence_utils/fastq_stats/.shed.yml
+++ b/tool_collections/galaxy_sequence_utils/fastq_stats/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastq_stats
+owner: devteam
+name: fastq_stats
+    

--- a/tool_collections/galaxy_sequence_utils/fastq_to_tabular/.shed.yml
+++ b/tool_collections/galaxy_sequence_utils/fastq_to_tabular/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastq_to_tabular
+owner: devteam
+name: fastq_to_tabular
+    

--- a/tool_collections/galaxy_sequence_utils/fastq_trimmer/.shed.yml
+++ b/tool_collections/galaxy_sequence_utils/fastq_trimmer/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastq_trimmer
+owner: devteam
+name: fastq_trimmer
+    

--- a/tool_collections/galaxy_sequence_utils/fastqtofasta/.shed.yml
+++ b/tool_collections/galaxy_sequence_utils/fastqtofasta/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastqtofasta
+owner: devteam
+name: fastqtofasta
+    

--- a/tool_collections/galaxy_sequence_utils/tabular_to_fastq/.shed.yml
+++ b/tool_collections/galaxy_sequence_utils/tabular_to_fastq/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/tabular_to_fastq
+owner: devteam
+name: tabular_to_fastq
+    

--- a/tool_collections/gatk/analyze_covariates/.shed.yml
+++ b/tool_collections/gatk/analyze_covariates/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/analyze_covariates
+owner: devteam
+name: analyze_covariates
+    

--- a/tool_collections/gatk/count_covariates/.shed.yml
+++ b/tool_collections/gatk/count_covariates/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/count_covariates
+owner: devteam
+name: count_covariates
+    

--- a/tool_collections/gatk/depth_of_coverage/.shed.yml
+++ b/tool_collections/gatk/depth_of_coverage/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/depth_of_coverage
+owner: devteam
+name: depth_of_coverage
+    

--- a/tool_collections/gatk/indel_realigner/.shed.yml
+++ b/tool_collections/gatk/indel_realigner/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/indel_realigner
+owner: devteam
+name: indel_realigner
+    

--- a/tool_collections/gatk/print_reads/.shed.yml
+++ b/tool_collections/gatk/print_reads/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/print_reads
+owner: devteam
+name: print_reads
+    

--- a/tool_collections/gatk/realigner_target_creator/.shed.yml
+++ b/tool_collections/gatk/realigner_target_creator/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/realigner_target_creator
+owner: devteam
+name: realigner_target_creator
+    

--- a/tool_collections/gatk/table_recalibration/.shed.yml
+++ b/tool_collections/gatk/table_recalibration/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/table_recalibration
+owner: devteam
+name: table_recalibration
+    

--- a/tool_collections/gatk/unified_genotyper/.shed.yml
+++ b/tool_collections/gatk/unified_genotyper/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/unified_genotyper
+owner: devteam
+name: unified_genotyper
+    

--- a/tool_collections/gatk/variant_annotator/.shed.yml
+++ b/tool_collections/gatk/variant_annotator/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/variant_annotator
+owner: devteam
+name: variant_annotator
+    

--- a/tool_collections/gatk/variant_apply_recalibration/.shed.yml
+++ b/tool_collections/gatk/variant_apply_recalibration/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/variant_apply_recalibration
+owner: devteam
+name: variant_apply_recalibration
+    

--- a/tool_collections/gatk/variant_combine/.shed.yml
+++ b/tool_collections/gatk/variant_combine/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/variant_combine
+owner: devteam
+name: variant_combine
+    

--- a/tool_collections/gatk/variant_eval/.shed.yml
+++ b/tool_collections/gatk/variant_eval/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/variant_eval
+owner: devteam
+name: variant_eval
+    

--- a/tool_collections/gatk/variant_filtration/.shed.yml
+++ b/tool_collections/gatk/variant_filtration/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/variant_filtration
+owner: devteam
+name: variant_filtration
+    

--- a/tool_collections/gatk/variant_recalibrator/.shed.yml
+++ b/tool_collections/gatk/variant_recalibrator/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/variant_recalibrator
+owner: devteam
+name: variant_recalibrator
+    

--- a/tool_collections/gatk/variant_select/.shed.yml
+++ b/tool_collections/gatk/variant_select/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/variant_select
+owner: devteam
+name: variant_select
+    

--- a/tool_collections/gatk/variants_validate/.shed.yml
+++ b/tool_collections/gatk/variants_validate/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/variants_validate
+owner: devteam
+name: variants_validate
+    

--- a/tool_collections/gops/basecoverage/.shed.yml
+++ b/tool_collections/gops/basecoverage/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/basecoverage
+owner: devteam
+name: basecoverage
+    

--- a/tool_collections/gops/cluster/.shed.yml
+++ b/tool_collections/gops/cluster/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/cluster
+owner: devteam
+name: cluster
+    

--- a/tool_collections/gops/complement/.shed.yml
+++ b/tool_collections/gops/complement/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/complement
+owner: devteam
+name: complement
+    

--- a/tool_collections/gops/concat/.shed.yml
+++ b/tool_collections/gops/concat/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/concat
+owner: devteam
+name: concat
+    

--- a/tool_collections/gops/coverage/.shed.yml
+++ b/tool_collections/gops/coverage/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/coverage
+owner: devteam
+name: coverage
+    

--- a/tool_collections/gops/flanking_features/.shed.yml
+++ b/tool_collections/gops/flanking_features/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/flanking_features
+owner: devteam
+name: flanking_features
+    

--- a/tool_collections/gops/get_flanks/.shed.yml
+++ b/tool_collections/gops/get_flanks/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/get_flanks
+owner: devteam
+name: get_flanks
+    

--- a/tool_collections/gops/intersect/.shed.yml
+++ b/tool_collections/gops/intersect/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/intersect
+owner: devteam
+name: intersect
+    

--- a/tool_collections/gops/join/.shed.yml
+++ b/tool_collections/gops/join/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/join
+owner: devteam
+name: join
+    

--- a/tool_collections/gops/merge/.shed.yml
+++ b/tool_collections/gops/merge/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/merge
+owner: devteam
+name: merge
+    

--- a/tool_collections/gops/subtract/.shed.yml
+++ b/tool_collections/gops/subtract/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/subtract
+owner: devteam
+name: subtract
+    

--- a/tool_collections/gops/subtract_query/.shed.yml
+++ b/tool_collections/gops/subtract_query/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/subtract_query
+owner: devteam
+name: subtract_query
+    

--- a/tool_collections/gops/tables_arithmetic_operations/.shed.yml
+++ b/tool_collections/gops/tables_arithmetic_operations/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/tables_arithmetic_operations
+owner: devteam
+name: tables_arithmetic_operations
+    

--- a/tool_collections/hgv/hgv_fundo/.shed.yml
+++ b/tool_collections/hgv/hgv_fundo/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/hgv_fundo
+owner: devteam
+name: hgv_fundo
+    

--- a/tool_collections/hgv/hgv_hilbertvis/.shed.yml
+++ b/tool_collections/hgv/hgv_hilbertvis/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/hgv_hilbertvis
+owner: devteam
+name: hgv_hilbertvis
+    

--- a/tool_collections/hgv/snpfreq/.shed.yml
+++ b/tool_collections/hgv/snpfreq/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/snpfreq
+owner: devteam
+name: snpfreq
+    

--- a/tool_collections/samtools/bam_to_sam/.shed.yml
+++ b/tool_collections/samtools/bam_to_sam/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/bam_to_sam
+owner: devteam
+name: bam_to_sam
+    

--- a/tool_collections/samtools/pileup_interval/.shed.yml
+++ b/tool_collections/samtools/pileup_interval/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/pileup_interval
+owner: devteam
+name: pileup_interval
+    

--- a/tool_collections/samtools/sam_to_bam/.shed.yml
+++ b/tool_collections/samtools/sam_to_bam/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/sam_to_bam
+owner: devteam
+name: sam_to_bam
+    

--- a/tool_collections/samtools/samtools_flagstat/.shed.yml
+++ b/tool_collections/samtools/samtools_flagstat/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/samtools_flagstat
+owner: devteam
+name: samtools_flagstat
+    

--- a/tool_collections/samtools/samtools_mpileup/.shed.yml
+++ b/tool_collections/samtools/samtools_mpileup/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/samtools_mpileup
+owner: devteam
+name: samtools_mpileup
+    

--- a/tool_collections/samtools/samtools_phase/.shed.yml
+++ b/tool_collections/samtools/samtools_phase/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/samtools_phase
+owner: devteam
+name: samtools_phase
+    

--- a/tool_collections/samtools/samtools_rmdup/.shed.yml
+++ b/tool_collections/samtools/samtools_rmdup/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/samtools_rmdup
+owner: devteam
+name: samtools_rmdup
+    

--- a/tool_collections/samtools/samtools_slice_bam/.shed.yml
+++ b/tool_collections/samtools/samtools_slice_bam/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/samtools_slice_bam
+owner: devteam
+name: samtools_slice_bam
+    

--- a/tool_collections/taxonomy/find_diag_hits/.shed.yml
+++ b/tool_collections/taxonomy/find_diag_hits/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/find_diag_hits
+owner: devteam
+name: find_diag_hits
+    

--- a/tool_collections/taxonomy/gi2taxonomy/.shed.yml
+++ b/tool_collections/taxonomy/gi2taxonomy/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/gi2taxonomy
+owner: devteam
+name: gi2taxonomy
+    

--- a/tool_collections/taxonomy/lca_wrapper/.shed.yml
+++ b/tool_collections/taxonomy/lca_wrapper/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/lca_wrapper
+owner: devteam
+name: lca_wrapper
+    

--- a/tool_collections/taxonomy/poisson2test/.shed.yml
+++ b/tool_collections/taxonomy/poisson2test/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/poisson2test
+owner: devteam
+name: poisson2test
+    

--- a/tool_collections/taxonomy/t2ps/.shed.yml
+++ b/tool_collections/taxonomy/t2ps/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/t2ps
+owner: devteam
+name: t2ps
+    

--- a/tool_collections/taxonomy/t2t_report/.shed.yml
+++ b/tool_collections/taxonomy/t2t_report/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/t2t_report
+owner: devteam
+name: t2t_report
+    

--- a/tool_collections/vcftools/vcftools_annotate/.shed.yml
+++ b/tool_collections/vcftools/vcftools_annotate/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/vcftools_annotate
+owner: devteam
+name: vcftools_annotate
+    

--- a/tool_collections/vcftools/vcftools_compare/.shed.yml
+++ b/tool_collections/vcftools/vcftools_compare/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/vcftools_compare
+owner: devteam
+name: vcftools_compare
+    

--- a/tool_collections/vcftools/vcftools_isec/.shed.yml
+++ b/tool_collections/vcftools/vcftools_isec/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/vcftools_isec
+owner: devteam
+name: vcftools_isec
+    

--- a/tool_collections/vcftools/vcftools_merge/.shed.yml
+++ b/tool_collections/vcftools/vcftools_merge/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/vcftools_merge
+owner: devteam
+name: vcftools_merge
+    

--- a/tool_collections/vcftools/vcftools_slice/.shed.yml
+++ b/tool_collections/vcftools/vcftools_slice/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/vcftools_slice
+owner: devteam
+name: vcftools_slice
+    

--- a/tool_collections/vcftools/vcftools_subset/.shed.yml
+++ b/tool_collections/vcftools/vcftools_subset/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/vcftools_subset
+owner: devteam
+name: vcftools_subset
+    

--- a/tools/add_value/.shed.yml
+++ b/tools/add_value/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/add_value
+owner: devteam
+name: add_value
+    

--- a/tools/annotation_profiler/.shed.yml
+++ b/tools/annotation_profiler/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/annotation_profiler
+owner: devteam
+name: annotation_profiler
+    

--- a/tools/bamleftalign/.shed.yml
+++ b/tools/bamleftalign/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/bamleftalign
+owner: devteam
+name: bamleftalign
+    

--- a/tools/best_regression_subsets/.shed.yml
+++ b/tools/best_regression_subsets/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/best_regression_subsets
+owner: devteam
+name: best_regression_subsets
+    

--- a/tools/blat_coverage_report/.shed.yml
+++ b/tools/blat_coverage_report/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/blat_coverage_report
+owner: devteam
+name: blat_coverage_report
+    

--- a/tools/blat_mapping/.shed.yml
+++ b/tools/blat_mapping/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/blat_mapping
+owner: devteam
+name: blat_mapping
+    

--- a/tools/bowtie2/.shed.yml
+++ b/tools/bowtie2/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/bowtie2
+owner: devteam
+name: bowtie2
+    

--- a/tools/bowtie_color_wrappers/.shed.yml
+++ b/tools/bowtie_color_wrappers/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/bowtie_color_wrappers
+owner: devteam
+name: bowtie_color_wrappers
+    

--- a/tools/bowtie_wrappers/.shed.yml
+++ b/tools/bowtie_wrappers/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/bowtie_wrappers
+owner: devteam
+name: bowtie_wrappers
+    

--- a/tools/bwa_wrappers/.shed.yml
+++ b/tools/bwa_wrappers/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/bwa_wrappers
+owner: devteam
+name: bwa_wrappers
+    

--- a/tools/canonical_correlation_analysis/.shed.yml
+++ b/tools/canonical_correlation_analysis/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/canonical_correlation_analysis
+owner: devteam
+name: canonical_correlation_analysis
+    

--- a/tools/categorize_elements_satisfying_criteria/.shed.yml
+++ b/tools/categorize_elements_satisfying_criteria/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/categorize_elements_satisfying_criteria
+owner: devteam
+name: categorize_elements_satisfying_criteria
+    

--- a/tools/ccat/.shed.yml
+++ b/tools/ccat/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/ccat
+owner: devteam
+name: ccat
+    

--- a/tools/change_case/.shed.yml
+++ b/tools/change_case/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/change_case
+owner: devteam
+name: change_case
+    

--- a/tools/clustalw/.shed.yml
+++ b/tools/clustalw/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/clustalw
+owner: devteam
+name: clustalw
+    

--- a/tools/column_maker/.shed.yml
+++ b/tools/column_maker/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/column_maker
+owner: devteam
+name: column_maker
+    

--- a/tools/compute_motif_frequencies_for_all_motifs/.shed.yml
+++ b/tools/compute_motif_frequencies_for_all_motifs/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/compute_motif_frequencies_for_all_motifs
+owner: devteam
+name: compute_motif_frequencies_for_all_motifs
+    

--- a/tools/compute_motifs_frequency/.shed.yml
+++ b/tools/compute_motifs_frequency/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/compute_motifs_frequency
+owner: devteam
+name: compute_motifs_frequency
+    

--- a/tools/compute_q_values/.shed.yml
+++ b/tools/compute_q_values/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/compute_q_values
+owner: devteam
+name: compute_q_values
+    

--- a/tools/condense_characters/.shed.yml
+++ b/tools/condense_characters/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/condense_characters
+owner: devteam
+name: condense_characters
+    

--- a/tools/convert_characters/.shed.yml
+++ b/tools/convert_characters/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/convert_characters
+owner: devteam
+name: convert_characters
+    

--- a/tools/convert_solid_color2nuc/.shed.yml
+++ b/tools/convert_solid_color2nuc/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/convert_solid_color2nuc
+owner: devteam
+name: convert_solid_color2nuc
+    

--- a/tools/correlation/.shed.yml
+++ b/tools/correlation/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/correlation
+owner: devteam
+name: correlation
+    

--- a/tools/count_gff_features/.shed.yml
+++ b/tools/count_gff_features/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/count_gff_features
+owner: devteam
+name: count_gff_features
+    

--- a/tools/ctd_batch/.shed.yml
+++ b/tools/ctd_batch/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/ctd_batch
+owner: devteam
+name: ctd_batch
+    

--- a/tools/cut_columns/.shed.yml
+++ b/tools/cut_columns/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/cut_columns
+owner: devteam
+name: cut_columns
+    

--- a/tools/delete_overlapping_indels/.shed.yml
+++ b/tools/delete_overlapping_indels/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/delete_overlapping_indels
+owner: devteam
+name: delete_overlapping_indels
+    

--- a/tools/dgidb_annotator/.shed.yml
+++ b/tools/dgidb_annotator/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/dgidb_annotator
+owner: devteam
+name: dgidb_annotator
+    

--- a/tools/divide_pg_snp/.shed.yml
+++ b/tools/divide_pg_snp/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/divide_pg_snp
+owner: devteam
+name: divide_pg_snp
+    

--- a/tools/dna_filtering/.shed.yml
+++ b/tools/dna_filtering/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/dna_filtering
+owner: devteam
+name: dna_filtering
+    

--- a/tools/draw_stacked_barplots/.shed.yml
+++ b/tools/draw_stacked_barplots/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/draw_stacked_barplots
+owner: devteam
+name: draw_stacked_barplots
+    

--- a/tools/dwt_cor_ava_perclass/.shed.yml
+++ b/tools/dwt_cor_ava_perclass/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/dwt_cor_ava_perclass
+owner: devteam
+name: dwt_cor_ava_perclass
+    

--- a/tools/dwt_cor_avb_all/.shed.yml
+++ b/tools/dwt_cor_avb_all/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/dwt_cor_avb_all
+owner: devteam
+name: dwt_cor_avb_all
+    

--- a/tools/dwt_ivc_all/.shed.yml
+++ b/tools/dwt_ivc_all/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/dwt_ivc_all
+owner: devteam
+name: dwt_ivc_all
+    

--- a/tools/dwt_var_perclass/.shed.yml
+++ b/tools/dwt_var_perclass/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/dwt_var_perclass
+owner: devteam
+name: dwt_var_perclass
+    

--- a/tools/dwt_var_perfeature/.shed.yml
+++ b/tools/dwt_var_perfeature/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/dwt_var_perfeature
+owner: devteam
+name: dwt_var_perfeature
+    

--- a/tools/emboss_5/.shed.yml
+++ b/tools/emboss_5/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/emboss_5
+owner: devteam
+name: emboss_5
+    

--- a/tools/express/.shed.yml
+++ b/tools/express/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/express
+owner: devteam
+name: express
+    

--- a/tools/fasta_compute_length/.shed.yml
+++ b/tools/fasta_compute_length/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fasta_compute_length
+owner: devteam
+name: fasta_compute_length
+    

--- a/tools/fasta_concatenate_by_species/.shed.yml
+++ b/tools/fasta_concatenate_by_species/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fasta_concatenate_by_species
+owner: devteam
+name: fasta_concatenate_by_species
+    

--- a/tools/fasta_filter_by_length/.shed.yml
+++ b/tools/fasta_filter_by_length/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fasta_filter_by_length
+owner: devteam
+name: fasta_filter_by_length
+    

--- a/tools/fasta_to_tabular/.shed.yml
+++ b/tools/fasta_to_tabular/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fasta_to_tabular
+owner: devteam
+name: fasta_to_tabular
+    

--- a/tools/fastq_trimmer_by_quality/.shed.yml
+++ b/tools/fastq_trimmer_by_quality/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastq_trimmer_by_quality
+owner: devteam
+name: fastq_trimmer_by_quality
+    

--- a/tools/fastqc/.shed.yml
+++ b/tools/fastqc/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastqc
+owner: devteam
+name: fastqc
+    

--- a/tools/fastqsolexa_to_fasta_qual/.shed.yml
+++ b/tools/fastqsolexa_to_fasta_qual/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/fastqsolexa_to_fasta_qual
+owner: devteam
+name: fastqsolexa_to_fasta_qual
+    

--- a/tools/featurecounter/.shed.yml
+++ b/tools/featurecounter/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/featurecounter
+owner: devteam
+name: featurecounter
+    

--- a/tools/filter_transcripts_via_tracking/.shed.yml
+++ b/tools/filter_transcripts_via_tracking/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/filter_transcripts_via_tracking
+owner: devteam
+name: filter_transcripts_via_tracking
+    

--- a/tools/generate_pc_lda_matrix/.shed.yml
+++ b/tools/generate_pc_lda_matrix/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/generate_pc_lda_matrix
+owner: devteam
+name: generate_pc_lda_matrix
+    

--- a/tools/getindelrates_3way/.shed.yml
+++ b/tools/getindelrates_3way/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/getindelrates_3way
+owner: devteam
+name: getindelrates_3way
+    

--- a/tools/getindels_2way/.shed.yml
+++ b/tools/getindels_2way/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/getindels_2way
+owner: devteam
+name: getindels_2way
+    

--- a/tools/gmaj/.shed.yml
+++ b/tools/gmaj/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/gmaj
+owner: devteam
+name: gmaj
+    

--- a/tools/histogram/.shed.yml
+++ b/tools/histogram/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/histogram
+owner: devteam
+name: histogram
+    

--- a/tools/indels_3way/.shed.yml
+++ b/tools/indels_3way/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/indels_3way
+owner: devteam
+name: indels_3way
+    

--- a/tools/kernel_canonical_correlation_analysis/.shed.yml
+++ b/tools/kernel_canonical_correlation_analysis/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/kernel_canonical_correlation_analysis
+owner: devteam
+name: kernel_canonical_correlation_analysis
+    

--- a/tools/kernel_principal_component_analysis/.shed.yml
+++ b/tools/kernel_principal_component_analysis/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/kernel_principal_component_analysis
+owner: devteam
+name: kernel_principal_component_analysis
+    

--- a/tools/lastz/.shed.yml
+++ b/tools/lastz/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/lastz
+owner: devteam
+name: lastz
+    

--- a/tools/lastz_paired_reads/.shed.yml
+++ b/tools/lastz_paired_reads/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/lastz_paired_reads
+owner: devteam
+name: lastz_paired_reads
+    

--- a/tools/lda_analysis/.shed.yml
+++ b/tools/lda_analysis/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/lda_analysis
+owner: devteam
+name: lda_analysis
+    

--- a/tools/linear_regression/.shed.yml
+++ b/tools/linear_regression/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/linear_regression
+owner: devteam
+name: linear_regression
+    

--- a/tools/logistic_regression_vif/.shed.yml
+++ b/tools/logistic_regression_vif/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/logistic_regression_vif
+owner: devteam
+name: logistic_regression_vif
+    

--- a/tools/macs/.shed.yml
+++ b/tools/macs/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/macs
+owner: devteam
+name: macs
+    

--- a/tools/maf_cpg_filter/.shed.yml
+++ b/tools/maf_cpg_filter/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/maf_cpg_filter
+owner: devteam
+name: maf_cpg_filter
+    

--- a/tools/mapping_to_ucsc/.shed.yml
+++ b/tools/mapping_to_ucsc/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/mapping_to_ucsc
+owner: devteam
+name: mapping_to_ucsc
+    

--- a/tools/megablast_wrapper/.shed.yml
+++ b/tools/megablast_wrapper/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/megablast_wrapper
+owner: devteam
+name: megablast_wrapper
+    

--- a/tools/megablast_xml_parser/.shed.yml
+++ b/tools/megablast_xml_parser/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/megablast_xml_parser
+owner: devteam
+name: megablast_xml_parser
+    

--- a/tools/merge_cols/.shed.yml
+++ b/tools/merge_cols/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/merge_cols
+owner: devteam
+name: merge_cols
+    

--- a/tools/microsatellite_birthdeath/.shed.yml
+++ b/tools/microsatellite_birthdeath/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/microsatellite_birthdeath
+owner: devteam
+name: microsatellite_birthdeath
+    

--- a/tools/microsats_alignment_level/.shed.yml
+++ b/tools/microsats_alignment_level/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/microsats_alignment_level
+owner: devteam
+name: microsats_alignment_level
+    

--- a/tools/microsats_mutability/.shed.yml
+++ b/tools/microsats_mutability/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/microsats_mutability
+owner: devteam
+name: microsats_mutability
+    

--- a/tools/mine/.shed.yml
+++ b/tools/mine/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/mine
+owner: devteam
+name: mine
+    

--- a/tools/multispecies_orthologous_microsats/.shed.yml
+++ b/tools/multispecies_orthologous_microsats/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/multispecies_orthologous_microsats
+owner: devteam
+name: multispecies_orthologous_microsats
+    

--- a/tools/mutate_snp_codon/.shed.yml
+++ b/tools/mutate_snp_codon/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/mutate_snp_codon
+owner: devteam
+name: mutate_snp_codon
+    

--- a/tools/partialr_square/.shed.yml
+++ b/tools/partialr_square/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/partialr_square
+owner: devteam
+name: partialr_square
+    

--- a/tools/pearson_correlation/.shed.yml
+++ b/tools/pearson_correlation/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/pearson_correlation
+owner: devteam
+name: pearson_correlation
+    

--- a/tools/pgsnp2gd_snp/.shed.yml
+++ b/tools/pgsnp2gd_snp/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/pgsnp2gd_snp
+owner: devteam
+name: pgsnp2gd_snp
+    

--- a/tools/picard/.shed.yml
+++ b/tools/picard/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/picard
+owner: devteam
+name: picard
+    

--- a/tools/pileup_parser/.shed.yml
+++ b/tools/pileup_parser/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/pileup_parser
+owner: devteam
+name: pileup_parser
+    

--- a/tools/plot_from_lda/.shed.yml
+++ b/tools/plot_from_lda/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/plot_from_lda
+owner: devteam
+name: plot_from_lda
+    

--- a/tools/principal_component_analysis/.shed.yml
+++ b/tools/principal_component_analysis/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/principal_component_analysis
+owner: devteam
+name: principal_component_analysis
+    

--- a/tools/quality_filter/.shed.yml
+++ b/tools/quality_filter/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/quality_filter
+owner: devteam
+name: quality_filter
+    

--- a/tools/rcve/.shed.yml
+++ b/tools/rcve/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/rcve
+owner: devteam
+name: rcve
+    

--- a/tools/remove_beginning/.shed.yml
+++ b/tools/remove_beginning/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/remove_beginning
+owner: devteam
+name: remove_beginning
+    

--- a/tools/rmap/.shed.yml
+++ b/tools/rmap/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/rmap
+owner: devteam
+name: rmap
+    

--- a/tools/rmapq/.shed.yml
+++ b/tools/rmapq/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/rmapq
+owner: devteam
+name: rmapq
+    

--- a/tools/sam2interval/.shed.yml
+++ b/tools/sam2interval/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/sam2interval
+owner: devteam
+name: sam2interval
+    

--- a/tools/sam_bitwise_flag_filter/.shed.yml
+++ b/tools/sam_bitwise_flag_filter/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/sam_bitwise_flag_filter
+owner: devteam
+name: sam_bitwise_flag_filter
+    

--- a/tools/sam_merge/.shed.yml
+++ b/tools/sam_merge/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/sam_merge
+owner: devteam
+name: sam_merge
+    

--- a/tools/sam_pileup/.shed.yml
+++ b/tools/sam_pileup/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/sam_pileup
+owner: devteam
+name: sam_pileup
+    

--- a/tools/samtool_filter2/.shed.yml
+++ b/tools/samtool_filter2/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/samtool_filter2
+owner: devteam
+name: samtool_filter2
+    

--- a/tools/scatterplot/.shed.yml
+++ b/tools/scatterplot/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/scatterplot
+owner: devteam
+name: scatterplot
+    

--- a/tools/short_reads_figure_high_quality_length/.shed.yml
+++ b/tools/short_reads_figure_high_quality_length/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/short_reads_figure_high_quality_length
+owner: devteam
+name: short_reads_figure_high_quality_length
+    

--- a/tools/short_reads_figure_score/.shed.yml
+++ b/tools/short_reads_figure_score/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/short_reads_figure_score
+owner: devteam
+name: short_reads_figure_score
+    

--- a/tools/short_reads_trim_seq/.shed.yml
+++ b/tools/short_reads_trim_seq/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/short_reads_trim_seq
+owner: devteam
+name: short_reads_trim_seq
+    

--- a/tools/show_beginning/.shed.yml
+++ b/tools/show_beginning/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/show_beginning
+owner: devteam
+name: show_beginning
+    

--- a/tools/show_tail/.shed.yml
+++ b/tools/show_tail/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/show_tail
+owner: devteam
+name: show_tail
+    

--- a/tools/sicer/.shed.yml
+++ b/tools/sicer/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/sicer
+owner: devteam
+name: sicer
+    

--- a/tools/split_paired_reads/.shed.yml
+++ b/tools/split_paired_reads/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/split_paired_reads
+owner: devteam
+name: split_paired_reads
+    

--- a/tools/substitution_rates/.shed.yml
+++ b/tools/substitution_rates/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/substitution_rates
+owner: devteam
+name: substitution_rates
+    

--- a/tools/substitutions/.shed.yml
+++ b/tools/substitutions/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/substitutions
+owner: devteam
+name: substitutions
+    

--- a/tools/t_test_two_samples/.shed.yml
+++ b/tools/t_test_two_samples/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/t_test_two_samples
+owner: devteam
+name: t_test_two_samples
+    

--- a/tools/table_annovar/.shed.yml
+++ b/tools/table_annovar/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/table_annovar
+owner: devteam
+name: table_annovar
+    

--- a/tools/tabular_to_fasta/.shed.yml
+++ b/tools/tabular_to_fasta/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/tabular_to_fasta
+owner: devteam
+name: tabular_to_fasta
+    

--- a/tools/tophat/.shed.yml
+++ b/tools/tophat/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/tophat
+owner: devteam
+name: tophat
+    

--- a/tools/tophat2/.shed.yml
+++ b/tools/tophat2/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/tophat2
+owner: devteam
+name: tophat2
+    

--- a/tools/tophat_fusion_post/.shed.yml
+++ b/tools/tophat_fusion_post/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/tophat_fusion_post
+owner: devteam
+name: tophat_fusion_post
+    

--- a/tools/trimmer/.shed.yml
+++ b/tools/trimmer/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/trimmer
+owner: devteam
+name: trimmer
+    

--- a/tools/ucsc_custom_track/.shed.yml
+++ b/tools/ucsc_custom_track/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/ucsc_custom_track
+owner: devteam
+name: ucsc_custom_track
+    

--- a/tools/varscan_version_2/.shed.yml
+++ b/tools/varscan_version_2/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/varscan_version_2
+owner: devteam
+name: varscan_version_2
+    

--- a/tools/vcf2pgsnp/.shed.yml
+++ b/tools/vcf2pgsnp/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/vcf2pgsnp
+owner: devteam
+name: vcf2pgsnp
+    

--- a/tools/vcf_annotate/.shed.yml
+++ b/tools/vcf_annotate/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/vcf_annotate
+owner: devteam
+name: vcf_annotate
+    

--- a/tools/vcf_extract/.shed.yml
+++ b/tools/vcf_extract/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/vcf_extract
+owner: devteam
+name: vcf_extract
+    

--- a/tools/vcf_filter/.shed.yml
+++ b/tools/vcf_filter/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/vcf_filter
+owner: devteam
+name: vcf_filter
+    

--- a/tools/vcf_intersect/.shed.yml
+++ b/tools/vcf_intersect/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/vcf_intersect
+owner: devteam
+name: vcf_intersect
+    

--- a/tools/weblogo3/.shed.yml
+++ b/tools/weblogo3/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/weblogo3
+owner: devteam
+name: weblogo3
+    

--- a/tools/weightedaverage/.shed.yml
+++ b/tools/weightedaverage/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/weightedaverage
+owner: devteam
+name: weightedaverage
+    

--- a/tools/windowsplitter/.shed.yml
+++ b/tools/windowsplitter/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/windowsplitter
+owner: devteam
+name: windowsplitter
+    

--- a/tools/xy_plot/.shed.yml
+++ b/tools/xy_plot/.shed.yml
@@ -1,0 +1,4 @@
+# repository published to https://toolshed.g2.bx.psu.edu/repos/devteam/xy_plot
+owner: devteam
+name: xy_plot
+    


### PR DESCRIPTION
**PRO**: keeps track of which directories map to which repositories.
**PRO**: simple uploads with planemo
- Upload a directory to either shed with `planemo shed_upload --shed_target [testtoolshed|toolshed]` (after configuring shed credentials).

**CON**: Kind of makes it harder to upload these repositories to the tool shed without planemo (got to make sure to exclude .shed.yml from tar if tarring outside `planemo`).

This is how I would do it - but I do not want to shove Planemo down anyone's throat.

_Update_
**PRO**: Upon further reflection - there is a counter to the claim this is `planemo` specific. It is called `.shed.yml` not `.planemo.yml` for a reason - it has other uses - for instance if someday we get to the point where the tool shed is monitoring github and say responding to tags and removing the upload step all together. These files would be helpful for that as well.
