### PR TITLE
Rename 'Tophat2' tool to 'Tophat'.

### DIFF
--- a/tools/tophat2/tophat2_wrapper.xml
+++ b/tools/tophat2/tophat2_wrapper.xml
@@ -1,4 +1,4 @@
-<tool id="tophat2" name="Tophat2" version="0.6">
+<tool id="tophat2" name="Tophat" version="0.6">
     <!-- Wrapper compatible with Tophat version 2.0.0+ -->
     <description>Gapped-read mapper for RNA-seq data</description>
     <version_command>tophat2 --version</version_command>


### PR DESCRIPTION
Per @jgoecks the old Tophat (1) tool should be deprecated and Tophat2 should always be preferred. Renaming Tophat2 to simply "Tophat" to make it clearer for users who may not understand why the tool is named Tophat2.

The Tophat2 tool lacks color space functionality but we don't think it's likely anyone would be using it (and the Tophat 1 tool could be used for it).