### PR TITLE
lookup the dbkey and not the value of a data_table

### DIFF
--- a/tool_collections/cufflinks/cuffdiff/cuffdiff_wrapper.xml
+++ b/tool_collections/cufflinks/cuffdiff/cuffdiff_wrapper.xml
@@ -38,7 +38,7 @@
                     $bias_correction.seq_source.ref_file
                 #else:
                     ## Built-in genome.
-                    ${__get_data_table_entry__('fasta_indexes', 'value', $gtf_input.dbkey, 'path')}
+                    ${__get_data_table_entry__('fasta_indexes', 'dbkey', $gtf_input.dbkey, 'path')}
                 #end if
             #end if
 

--- a/tool_collections/cufflinks/cuffquant/cuffquant_wrapper.xml
+++ b/tool_collections/cufflinks/cuffquant/cuffquant_wrapper.xml
@@ -34,7 +34,7 @@
                     $bias_correction.seq_source.ref_file
                 #else:
                     ## Built-in genome.
-                    ${__get_data_table_entry__('fasta_indexes', 'value', $gtf_input.dbkey, 'path')}
+                    ${__get_data_table_entry__('fasta_indexes', 'dbkey', $gtf_input.dbkey, 'path')}
                 #end if
             #end if
 


### PR DESCRIPTION
The option "Perform Bias Correction" is not working for us. I found the following thread that is describing our issue:
http://gmod.827538.n3.nabble.com/Solution-for-Error-running-cuffdiff-Error-cannot-open-reference-GTF-file-CONDITION-CONTROL-for-readig-td3733770.html

But is seems to be not fixed. I was able to track it down to the following line:
https://github.com/galaxyproject/tools-devteam/blob/master/tool_collections/cufflinks/cuffdiff/cuffdiff_wrapper.xml#L41

`value` needs to be replaced by `dbkey` or?
