### PR TITLE
Fastqc: fix format detection when history name does not incl. the extension

### DIFF
--- a/tools/fastqc/rgFastQC.py
+++ b/tools/fastqc/rgFastQC.py
@@ -79,7 +79,14 @@ class FastQCRunner(object):
         
         # Replace unwanted or problematic charaters in the input file name
         self.fastqinfilename = re.sub(ur'[^a-zA-Z0-9_\-\.]', '_', os.path.basename(infname))
-        
+        # check that the symbolic link gets a proper ending, fastqc seems to ignore the given format otherwise
+        if 'fastq' in opts.informat:
+            # with fastq the .ext is ignored, but when a format is actually passed it must comply with fastqc's 
+            # accepted formats..
+            opts.informat = 'fastq'
+        elif not self.fastqinfilename.endswith(opts.informat):
+            self.fastqinfilename += '.%s' % opts.informat
+
         # Build the Commandline from the given parameters
         command_line = [opts.executable, '--outdir %s' % opts.outputdir]
         if opts.contaminants != None:
@@ -89,6 +96,7 @@ class FastQCRunner(object):
         command_line.append('--quiet')
         command_line.append('--extract') # to access the output text file
         command_line.append(self.fastqinfilename)
+        command_line.append('-f %s' % opts.informat)
         self.command_line = ' '.join(command_line)
 
     def copy_output_file_to_dataset(self):


### PR DESCRIPTION
With for example a bam file that does not have its extension in its history name fastqc will fail with a message that indicates that it tries to read a fastq instead of bam(see below). This patch fixes this.

Fatal error: Exit code 1 ()
Failed to process Filtered_BAM_file1_bowtie2
uk.ac.babraham.FastQC.Sequence.SequenceFormatException: ID line didn't start with '@'
	at uk.ac.babraham.FastQC.Sequence.FastQFile.readNext(FastQFile.java:158)
	at uk.ac.babraham.FastQC.Sequence.FastQFile.<init>(FastQFile.java:89)
	at uk.ac.babraham.FastQC.Sequence.SequenceFactory.getSequenceFile(SequenceFactory.java:104)
	at uk.ac.babraham.FastQC.Sequence.SequenceFactory.getSequenceFile(SequenceFactory.java:62)
	at uk.ac.babraham.FastQC.Analysis.OfflineRunner.processFile(OfflineRunner.java:122)
	at uk.ac.babraham.FastQC.Analysis.OfflineRunner.<init>(OfflineRunner.java:95)
	at uk.ac.babraham.FastQC.FastQCApplication.main(FastQCApplication.java:308)
Traceback (most recent call last):
  File "/d/toolshed_dev/toolshed.g2.bx.psu.edu/repos/devteam/fastqc/0b201de108b9/fastqc/rgFastQC.py", line 154, in <module>
    fastqc_runner.run_fastqc()
  File "/d/toolshed_dev/toolshed.g2.bx.psu.edu/repos/devteam/fastqc/0b201de108b9/fastqc/rgFastQC.py", line 128, in run_fastqc
    self.copy_output_file_to_dataset()
  File "/d/toolshed_dev/toolshed.g2.bx.psu.edu/repos/devteam/fastqc/0b201de108b9/fastqc/rgFastQC.py", line 101, in copy_output_file_to_dataset
    with open(result_file[0], 'rb') as fsrc:
IndexError: list index out of range

