### PR TITLE
Remove line continuation char (\) from GATK Picard Index Data Manager

### DIFF
--- a/data_managers/data_manager_gatk_picard_index_builder/data_manager/data_manager_gatk_picard_index_builder.xml
+++ b/data_managers/data_manager_gatk_picard_index_builder/data_manager/data_manager_gatk_picard_index_builder.xml
@@ -5,11 +5,11 @@
         <requirement type="package" version="1.56.0">picard</requirement>
     </requirements>
     <command interpreter="python">
-        data_manager_gatk_picard_index_builder.py "${out_file}" \
-            --jar "\$JAVA_JAR_PATH/CreateSequenceDictionary.jar" \
-            --fasta_filename "${all_fasta_source.fields.path}" \
-            --fasta_dbkey "${all_fasta_source.fields.dbkey}" \
-            --fasta_description "${all_fasta_source.fields.name}" \
+        data_manager_gatk_picard_index_builder.py "${out_file}"
+            --jar "\$JAVA_JAR_PATH/CreateSequenceDictionary.jar"
+            --fasta_filename "${all_fasta_source.fields.path}"
+            --fasta_dbkey "${all_fasta_source.fields.dbkey}"
+            --fasta_description "${all_fasta_source.fields.name}"
             --data_table_name "gatk_picard_indexes"
     </command>
     <inputs>


### PR DESCRIPTION
NB: We should determine if this used to work as-is, and if some job running change in Galaxy broke this tool.

Example of behavior, notice that the arguments after a \ have a space prepended before the '--argname':

argv ['/path/galaxy-blankenberg/installed/toolshed.g2.bx.psu.edu/repos/devteam/data_manager_gatk_picard_index_builder/a15709ad26ea/data_manager_gatk_picard_index_builder/data_manager/data_manager_gatk_picard_index_builder.py', '/path/galaxy-blankenberg/database/files/000/dataset_4.dat', ' --jar', '/path/shed_tools/galaxy-blankenberg/tool_dependency_dir/picard/1.56.0/devteam/package_picard_1_56_0/99a28567c3a3/jars/CreateSequenceDictionary.jar', ' --fasta_filename', '/path/galaxy-blankenberg/tool-data/hg19/seq/hg19.fa', ' --fasta_dbkey', 'hg19', ' --fasta_description', 'hg19', ' --data_table_name', 'gatk_picard_indexes']