### PR TITLE
Fix Bowtie2 tool not failing properly when non-zero exit code is provide...

### DIFF
--- a/tools/bowtie2/bowtie2_wrapper.xml
+++ b/tools/bowtie2/bowtie2_wrapper.xml
@@ -154,10 +154,10 @@
 
         ## rename unaligned sequence files
         #if $library.type == "paired" and $output_unaligned_reads_l and $output_unaligned_reads_r:
-            #set left  = str($output_unaligned_reads_l)[:-3] + '1.dat'
-            #set right = str($output_unaligned_reads_l)[:-3] + '2.dat'
-            &amp;&amp; mv "${ left }" "${ output_unaligned_reads_l }"
-            &amp;&amp; mv "${ right }" "${ output_unaligned_reads_r }"
+            #from os.path import splitext
+            #set _unaligned_root, _unaligned_ext = splitext( str( $output_unaligned_reads_l ) )
+            &amp;&amp; mv "${ _unaligned_root }.1${_unaligned_ext}" "${ output_unaligned_reads_l }"
+            &amp;&amp; mv "${ _unaligned_root }.2${_unaligned_ext}" "${ output_unaligned_reads_r }"
         #end if
         
     </command>

--- a/tools/bowtie2/bowtie2_wrapper.xml
+++ b/tools/bowtie2/bowtie2_wrapper.xml
@@ -1,4 +1,4 @@
-<tool id="bowtie2" name="Bowtie2" version="0.4">
+<tool id="bowtie2" name="Bowtie2" version="0.5">
     <!-- Wrapper compatible with Bowtie version 2.2.4 -->
     <description>- map reads against reference genome</description>
     <version_command>bowtie2 --version</version_command>
@@ -145,18 +145,19 @@
         
         #elif str( $analysis_type.analysis_type_selector ) == "cline":
             ${analysis_type.cline}
-        #end if    
+        #end if
         
+        -S "galaxy_bowtie_2_output.sam" &amp;&amp;
+
         ## view/sort and output BAM file
-        | samtools view -Su - | samtools sort -o - - > $output
+        ( samtools view -Su "galaxy_bowtie_2_output.sam" | samtools sort -o - - > $output )
 
         ## rename unaligned sequence files
         #if $library.type == "paired" and $output_unaligned_reads_l and $output_unaligned_reads_r:
-            #set left  = str($output_unaligned_reads_l).replace( '.dat', '.1.dat' )
-            #set right = str($output_unaligned_reads_l).replace( '.dat', '.2.dat' )
-        
-            ; mv $left $output_unaligned_reads_l;
-            mv $right $output_unaligned_reads_r
+            #set left  = str($output_unaligned_reads_l)[:-3] + '1.dat'
+            #set right = str($output_unaligned_reads_l)[:-3] + '2.dat'
+            &amp;&amp; mv "${ left }" "${ output_unaligned_reads_l }"
+            &amp;&amp; mv "${ right }" "${ output_unaligned_reads_r }"
         #end if
         
     </command>


### PR DESCRIPTION
...d. We cannot use pipes due to needing the return code from the initial command and we can't assume that we are bash or another shell that has e.g. PIPESTATUS.