### PR TITLE
fix installation where python will install libraries into `$HOME/lib64`

### DIFF
--- a/packages/package_galaxy_utils_1_0/tool_dependencies.xml
+++ b/packages/package_galaxy_utils_1_0/tool_dependencies.xml
@@ -5,9 +5,13 @@
             <actions>
                 <action type="download_by_url">http://depot.galaxyproject.org/package/source/galaxy_sequence_utils/galaxy_sequence_utils-1.0.0.tgz</action>
                 <action type="make_directory">$INSTALL_DIR/lib/python</action>
-                <action type="shell_command">export PYTHONPATH=$PYTHONPATH:$INSTALL_DIR/lib/python &amp;&amp; python setup.py install --home $INSTALL_DIR</action>
+                <action type="shell_command">
+                    export PYTHONPATH=$PYTHONPATH:$INSTALL_DIR/lib/python &amp;&amp;
+                    python setup.py install --install-lib $INSTALL_DIR/lib/python --install-scripts $INSTALL_DIR/bin
+                </action>
                 <action type="set_environment">
                     <environment_variable name="PYTHONPATH" action="prepend_to">$INSTALL_DIR/lib/python</environment_variable>
+                    <environment_variable name="GALAXY_SEQUENCE_UTILS_ROOT" action="set_to">$INSTALL_DIR</environment_variable>
                 </action>
             </actions>
         </install>


### PR DESCRIPTION
This ensures that libraries are installed into `$HOME/lib64`.