### PR TITLE
samtool_filter2 cleanup.

### DIFF
--- a/tools/samtool_filter2/samtool_filter2.xml
+++ b/tools/samtool_filter2/samtool_filter2.xml
@@ -3,58 +3,36 @@
   <requirements>
     <requirement type="package" version="0.1.18">samtools</requirement>
   </requirements>
-  <!-- 
-    samtools view [-bchuHS] [-t in.refList] [-o output] [-f reqFlag] [-F skipFlag] [-q minMapQ] [-l library] [-r readGroup] [-R rgFile] <in.bam>|<in.sam> [region1 [...]]
-     Usage:   samtools view [options] <in.bam>|<in.sam> [region1 [...]]
-
-     Options: -b       output BAM
-              -h       print header for the SAM output
-              -H       print header only (no alignments)
-              -S       input is SAM
-              -u       uncompressed BAM output (force -b)
-              -1       fast compression (force -b)
-              -x       output FLAG in HEX (samtools-C specific)
-              -X       output FLAG in string (samtools-C specific)
-              -c       print only the count of matching records
-              -L FILE  output alignments overlapping the input BED FILE [null]
-              -t FILE  list of reference names and lengths (force -S) [null]
-              -T FILE  reference sequence file (force -S) [null]
-              -o FILE  output file name [stdout]
-              -R FILE  list of read groups to be outputted [null]
-              -f INT   required flag, 0 for unset [0]
-              -F INT   filtering flag, 0 for unset [0]
-              -q INT   minimum mapping quality [0]
-              -l STR   only output reads in library STR [null]
-              -r STR   only output reads in read group STR [null]
-              -?       longer help
-  -->
+  <stdio>
+    <exit_code range="1:" />
+  </stdio>
   <command>
+<![CDATA[
 ##set up input files, regions requires input.bam and input.bai
 #if isinstance($input1.datatype, $__app__.datatypes_registry.get_datatype_by_extension('bam').__class__):
   #set $input = 'input.bam'
-  ln -s $input1 $input  &amp;&amp;
-  ln -s $input1.metadata.bam_index input.bai  &amp;&amp;
+  ln -s "$input1" $input &&
+  ln -s "$input1.metadata.bam_index" input.bai &&
 #elif isinstance($input1.datatype, $__app__.datatypes_registry.get_datatype_by_extension('sam').__class__):
   #set $input = 'input.sam'
-  ln -s $input1 $input  &amp;&amp;
+  ln -s "$input1" $input &&
 #end if
 samtools view -o "$output1" $header
-  
+
   #if $input1.datatype.file_ext == 'sam':
    -S
   #end if
 
   #if $outputtype.__str__ == "bam":
-      -b 
+      -b
   #end if
-  
-  
+
   #if $mapq.__str__ != '':
    -q $mapq
   #end if
   #if $flag.filter.__str__ == 'yes':
    #if $flag.reqBits.__str__ != 'None':
-     #set $reqs = $flag.reqBits.__str__.split(',') 
+     #set $reqs = $flag.reqBits.__str__.split(',')
      #set $reqFlag = 0
      #for $xn in $reqs:
        #set $reqFlag += int(xn,16)
@@ -62,7 +40,7 @@ samtools view -o "$output1" $header
      -f $hex($reqFlag)
    #end if
    #if $flag.skipBits.__str__ != 'None':
-     #set $skips = $flag.skipBits.__str__.split(',') 
+     #set $skips = $flag.skipBits.__str__.split(',')
      #set $skipFlag = 0
      #for $xn in $skips:
        #set $skipFlag += int(xn,16)
@@ -77,23 +55,24 @@ samtools view -o "$output1" $header
     -l $library
   #end if
   #if $bed_file.__str__ != "None" and len($bed_file.__str__) > 0:
-    -L $bed_file
+    -L "$bed_file"
   #end if
   $input
   #if $regions.__str__.strip() != '' and $input1.datatype.file_ext == 'bam':
     $regions.__str__.strip()
   #end if
   ## need to redirect stderr message so galaxy does not think this failed
-  2>&amp;1
+  2>&1
+]]>
   </command>
   <inputs>
-    <param name="input1" type="data" format="sam,bam" label="SAM or BAM File to Filter" />
+    <param name="input1" type="data" format="sam,bam" label="SAM or BAM file to filter" />
     <param name="header" type="select" label="Header in output">
       <option value="-h">Include Header</option>
       <option value="">Exclude Header</option>
       <option value="-H">Only the Header</option>
     </param>
-    <param name="mapq" type="integer" value="" optional="true" label="Minimum MAPQ quality score">
+    <param name="mapq" type="integer" value="" optional="true" label="Minimum MAPQ quality score" help="(-q)">
       <validator type="in_range" message="The MAPQ quality score can't be negative" min="0"/>
     </param>
     <conditional name="flag">
@@ -103,7 +82,7 @@ samtools view -o "$output1" $header
       </param>
       <when value="no"/>
       <when value="yes">
-        <param name="reqBits" type="select" multiple="true" display="checkboxes" label="Only output alignments with all of these flag bits set" >
+        <param name="reqBits" type="select" multiple="true" display="checkboxes" label="Only output alignments with all of these flag bits set" help="(-f)">
           <option value="0x0001">Read is paired</option>
           <option value="0x0002">Read is mapped in a proper pair</option>
           <option value="0x0004">The read is unmapped</option>
@@ -116,7 +95,7 @@ samtools view -o "$output1" $header
           <option value="0x0200">The read fails platform/vendor quality checks</option>
           <option value="0x0400">The read is a PCR or optical duplicate</option>
         </param>
-        <param name="skipBits" type="select" multiple="true" display="checkboxes" label="Skip alignments with any of these flag bits set" >
+        <param name="skipBits" type="select" multiple="true" display="checkboxes" label="Skip alignments with any of these flag bits set" help="(-F)">
           <option value="0x0001">Read is paired</option>
           <option value="0x0002">Read is mapped in a proper pair</option>
           <option value="0x0004">The read is unmapped</option>
@@ -132,15 +111,15 @@ samtools view -o "$output1" $header
       </when>
     </conditional>
     <param name="library" type="text" value="" size="20" label="Select alignments from Library"
-           help="Requires headers in the input SAM or BAM, otherwise no alignments will be output."/>
-    <param name="read_group" type="text" value="" size="20" label="Select alignments from Read Group" 
-           help="Requires headers in the input SAM or BAM, otherwise no alignments will be output."/>
-    <param name="bed_file" type="data" format="bed" optional="true" label="Output alignments overlapping the regions in the BED FILE"/>
-    <param name="regions" type="text" value="" size="180" label="Select regions (only used when the input is in BAM format)" 
+           help="(-l) Requires headers in the input SAM or BAM, otherwise no alignments will be output"/>
+    <param name="read_group" type="text" value="" size="20" label="Select alignments from Read Group"
+           help="(-r) Requires headers in the input SAM or BAM, otherwise no alignments will be output"/>
+    <param name="bed_file" type="data" format="bed" optional="true" label="Output alignments overlapping the regions in the BED FILE" help="(-L)"/>
+    <param name="regions" type="text" value="" size="180" label="Select regions (only used when the input is in BAM format)"
            help="region should be presented in one of the following formats: `chr1', `chr2:1,000' and `chr3:1000-2,000'"/>
     <param name="outputtype" type="select" label="Select the output format">
-        <option value="bam">bam</option>
-        <option value="sam">sam</option>
+        <option value="bam">BAM (-b)</option>
+        <option value="sam">SAM</option>
     </param>
   </inputs>
   <outputs>
@@ -157,11 +136,11 @@ samtools view -o "$output1" $header
       <param name="filter" value="yes"/>
       <param name="reqBits" value="0x0080"/>
       <param name="outputtype" value="sam"/>
-      <output name="output1" >
-       <assert_contents> 
-         <has_text text="141" /> 
+      <output name="output1">
+       <assert_contents>
+         <has_text text="141" />
          <not_has_text text="77" />
-       </assert_contents> 
+       </assert_contents>
       </output>
     </test>
     <test>
@@ -170,11 +149,11 @@ samtools view -o "$output1" $header
       <param name="filter" value="no"/>
       <param name="read_group" value="rg1"/>
       <param name="outputtype" value="sam"/>
-      <output name="output1" >
-       <assert_contents> 
-         <has_text text="rg1" /> 
+      <output name="output1">
+       <assert_contents>
+         <has_text text="rg1" />
          <not_has_text text="rg2" />
-       </assert_contents> 
+       </assert_contents>
       </output>
     </test>
     <test>
@@ -184,20 +163,18 @@ samtools view -o "$output1" $header
       <param name="skipBits" value="0x0008"/>
       <param name="mapq" value="250"/>
       <param name="outputtype" value="sam"/>
-      <output name="output1" >
-       <assert_contents> 
-         <has_text text="both_reads_align_clip_marked" /> 
+      <output name="output1">
+       <assert_contents>
+         <has_text text="both_reads_align_clip_marked" />
          <not_has_text text="both_reads_present_only_first_aligns" />
-       </assert_contents> 
+       </assert_contents>
       </output>
     </test>
   </tests>
   <help>
-  
-
 **What it does**
 
-This tool uses the samtools view command in SAMTools_ toolkit to filter a SAM or BAM file on the MAPQ (mapping quality), FLAG bits, Read Group, Library, or region.
+This tool uses the samtools view command in SAMtools_ toolkit to filter a SAM or BAM file on the MAPQ (mapping quality), FLAG bits, Read Group, Library, or region.
 
 **Input**
 
@@ -209,14 +186,14 @@ The output file will be SAM or BAM (depending on the chosen option), filtered by
 
 **Options**
 
-Filtering by read group or library requires headers in the input SAM or BAM file.   
+Filtering by read group or library requires headers in the input SAM or BAM file.
 
-If regions are specified, only alignments overlapping the specified regions will be output.  An alignment may be given multiple times if it is overlapping several regions.  
+If regions are specified, only alignments overlapping the specified regions will be output.  An alignment may be given multiple times if it is overlapping several regions.
 A region can be presented, for example, in the following format::
 
   chr2	(the whole chr2)
-  chr2:1000000	 (region starting from 1,000,000bp) 
-  chr2:1,000,000-2,000,000	(region between 1,000,000 and 2,000,000bp including the end points). 
+  chr2:1000000	 (region starting from 1,000,000bp)
+  chr2:1,000,000-2,000,000	(region between 1,000,000 and 2,000,000bp including the end points).
 
 Note:  The coordinate is 1-based.
 
@@ -226,7 +203,7 @@ Multiple regions may be specified, separated by a space character::
 
 
 
-.. _SAMTools: http://samtools.sourceforge.net/samtools.shtml
+.. _SAMtools: http://samtools.sourceforge.net/
 
   </help>
 </tool>


### PR DESCRIPTION
Detect command errors.
Use CDATA.
Quote data file paths in command.
Add argument names to parameters' help.
Remove trailing whitespaces.