### PR TITLE
Add option for reporting unmapped.bam

### DIFF
--- a/tools/tophat2/tophat2_wrapper.xml
+++ b/tools/tophat2/tophat2_wrapper.xml
@@ -182,13 +182,12 @@
               <param name="min_intron_length" type="integer" value="70" label="The minimum intron length" help="TopHat will ignore donor/acceptor pairs closer than this many bases apart." />
               <param name="max_intron_length" type="integer" value="500000" label="The maximum intron length" help="When searching for junctions ab initio, TopHat will ignore donor/acceptor pairs farther than this many bases apart, except when such a pair is supported by a split segment alignment of a long read." />
               <expand macro="indel_searchConditional" />
-    alignments (number of reads divided by average depth of coverage)" help="0.0 to 1.0 (0 to turn off)" />
               <param name="max_multihits" type="integer" value="20" label="Maximum number of alignments to be allowed" />
               <param name="min_segment_intron" type="integer" value="50" label="Minimum intron length that may be found during split-segment (default) search" />
               <param name="max_segment_intron" type="integer" value="500000" label="Maximum intron length that may be found during split-segment (default) search" />
               <param name="seg_mismatches" type="integer" min="0" max="3" value="2" label="Number of mismatches allowed in each segment alignment for reads mapped independently" />
               <param name="seg_length" type="integer" value="25" label="Minimum length of read segments" />
-          
+              <param name="output_unmapped" type="boolean" truevalue="true" falsevalue="false" checked="false" label="Report unmapped BAM" help="If checked, a BAM with the unmapped reads will be added to the history" />
               <!-- Options for supplying own junctions. -->
               <expand macro="own_junctionsConditional" />
               <!-- Coverage search. -->
@@ -292,6 +291,11 @@
         <data format="bam" name="accepted_hits" label="${tool.name} on ${on_string}: accepted_hits" from_work_dir="tophat_out/accepted_hits.bam">
           <expand macro="dbKeyActions" />
         </data>
+        <data format="bam" name="unmapped" label="${tool.name} on ${on_string}: unmapped" from_work_dir="tophat_out/unmapped.bam">
+            <filter>(params['settingsType'] == 'full' and params['output_unmapped'])</filter>
+            <expand macro="dbKeyActions" />
+        </data>
+
     </outputs>
 
     <macros>

--- a/tools/tophat2/tophat2_wrapper.xml
+++ b/tools/tophat2/tophat2_wrapper.xml
@@ -1,4 +1,4 @@
-<tool id="tophat2" name="Tophat" version="0.7">
+<tool id="tophat2" name="Tophat" version="0.8">
     <!-- Wrapper compatible with Tophat version 2.0.0+ -->
     <description>Gapped-read mapper for RNA-seq data</description>
     <version_command>tophat2 --version</version_command>


### PR DESCRIPTION
Useful to extract unmapped reads for further analysis (i.e. identification of expressed viral sequences from human RNA-Seq data)