### PR TITLE
Correct reStructuredText typo

### DIFF
--- a/tools/microsatellite_birthdeath/microsatellite_birthdeath.xml
+++ b/tools/microsatellite_birthdeath/microsatellite_birthdeath.xml
@@ -63,6 +63,7 @@
 **What it does**
 
 This tool uses raw orthologous microsatellite clusters (identified by the tool "Extract orthologous microsatellites") to identify microsatellite births and deaths along individual lineages of a phylogenetic tree.
+
 -----
 
 .. class:: warningmark


### PR DESCRIPTION
The dashed line is being treated as marker for a section header instead of as an horizontal line.