### PR TITLE
Silence warnings due to missing <when> tags

### DIFF
--- a/tool_collections/bamtools/bamtools_split/bamtools-split.xml
+++ b/tool_collections/bamtools/bamtools_split/bamtools-split.xml
@@ -44,6 +44,9 @@
         <option value="-reference">Reference name (-reference)</option>
         <option value="-tag">Specific tag (-tag)</option>
       </param>
+      <when value="-mapped" />
+      <when value="-paired" />
+      <when value="-reference" />
       <when value="-tag">
         <param name="tag_name" type="text" value="NM" label="Enter tag name here" help="For example, to split on NM tag enter &quot;NM&quot;"/>
       </when>

--- a/tools/mine/MINE.xml
+++ b/tools/mine/MINE.xml
@@ -47,6 +47,7 @@
       <when value="adjacentPairs">
         <param type="boolean" truevalue="--permute" false_value="" name="permute" checked="False" />
       </when>
+      <when value="allPairs" />
     </conditional>
     
     <param type="float" value="0" name="cv" />


### PR DESCRIPTION
Two tools were missing tags causing warnings when parsed by galaxy.