### PR TITLE
Update tool_dependencies.xml

### DIFF
--- a/packages/package_libgd_2_1_0/tool_dependencies.xml
+++ b/packages/package_libgd_2_1_0/tool_dependencies.xml
@@ -17,6 +17,7 @@
                 <action type="set_environment">
                   <environment_variable action="set_to" name="GD_ROOT">$INSTALL_DIR</environment_variable>
                   <environment_variable action="prepend_to" name="PKG_CONFIG_PATH">$INSTALL_DIR/lib/pkgconfig</environment_variable>
+                  <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
                 </action>
             </actions>
         </install>


### PR DESCRIPTION
This is needed to find the `gdlib-config` shell script, which is needed to get PERL libraries compiled/installed.