### PR TITLE
Adopt for cufflinks error message

### DIFF
--- a/tool_collections/cufflinks/cuff_macros.xml
+++ b/tool_collections/cufflinks/cuff_macros.xml
@@ -10,8 +10,8 @@
     <stdio>
         <exit_code range="1:" />
         <exit_code range=":-1" />
-        <regex match="Error:" />
-        <regex match="Exception:" />
+        <regex match="Error" />
+        <regex match="Exception" />
     </stdio>
   </xml>
   <xml name="condition_inputs">


### PR DESCRIPTION
Cufflinks can produce the following error message and this isn't catched by the current stdio tag.
```
Error running cufflinks.
return code = -11
Command line:
```