### PR TITLE
Fix failed functional test

### DIFF
--- a/tools/picard/picard_MarkDuplicatesWithMateCigar.xml
+++ b/tools/picard/picard_MarkDuplicatesWithMateCigar.xml
@@ -14,10 +14,8 @@
     OUTPUT="${outFile}"
     
     METRICS_FILE="${metrics_file}"
-    #for $element in $comments:
-      COMMENT="${element.comment}"
-    #end for
-    
+    COMMENT="${comment}"
+
     MINIMUM_DISTANCE="${minimum_distance}"
     SKIP_PAIRS_WITH_NO_MATE_CIGAR="${skip_pairs_with_no_mate_cigar}"
     


### PR DESCRIPTION
The functional test for this tool fails.  Looking at the XML wrapper, it looks like $comments is invalid....it doesn't exist anywhere else in the xml file.  I know that comments can be specified multiple times however there is no way to get the comments fields to appear multiple times in the UI as far as I can tell.  This change allows the comment to be added and still pass.