### PR TITLE
Correct line 43 of picard_MergeBamAlignment.xml

### DIFF
--- a/tools/picard/picard_MergeBamAlignment.xml
+++ b/tools/picard/picard_MergeBamAlignment.xml
@@ -1,4 +1,4 @@
-<tool name="MergeBamAlignment" id="picard_MergeBamAlignment" version="1.126.0">
+<tool name="MergeBamAlignment" id="picard_MergeBamAlignment" version="1.126.1">
   <description>merge alignment data with additional info stored in an unmapped BAM dataset</description>
   <macros>
     <import>picard_macros.xml</import>

--- a/tools/picard/picard_MergeBamAlignment.xml
+++ b/tools/picard/picard_MergeBamAlignment.xml
@@ -40,7 +40,7 @@
           READ1_ALIGNED_BAM="${dataset.read1_aligned_bam}"
         #end for
         #for $dataset in $aligned_or_read1_and_read2.read2_aligned_bams:
-          READ2_ALIGNED_BAM="${dataset.read1_aligned_bam}"
+          READ2_ALIGNED_BAM="${dataset.read2_aligned_bam}"
         #end for
       #else
         #for $dataset in $aligned_or_read1_and_read2.read1_aligned_bams:


### PR DESCRIPTION
Line 128 specifies a parameter named read2_aligned_bam from the read2_aligned_bams repeat block. On line 43, this parameter is referenced as "read1_aligned_bam." Whether or not this makes a difference is beyond my understanding of the internals, but consistency is desirable. Alternatively, if this is not managed behind the scenes by the galaxy library then this would have produced incorrect output in the past.