### PR TITLE
data_manager_sam_fasta_index_builder error on missing fasta file

### DIFF
--- a/data_managers/data_manager_sam_fasta_index_builder/data_manager/data_manager_sam_fasta_index_builder.py
+++ b/data_managers/data_manager_sam_fasta_index_builder/data_manager/data_manager_sam_fasta_index_builder.py
@@ -27,6 +27,7 @@ def get_id_name( params, dbkey, fasta_description=None):
 
 def build_sam_index( data_manager_dict, fasta_filename, target_directory, dbkey, sequence_id, sequence_name, data_table_name=DEFAULT_DATA_TABLE_NAME ):
     #TODO: allow multiple FASTA input files
+    assert os.path.exists( fasta_filename ), 'FASTA file "%s" is missing, cannot build samtools index.' % fasta_filename
     fasta_base_name = os.path.split( fasta_filename )[-1]
     sym_linked_fasta_filename = os.path.join( target_directory, fasta_base_name )
     os.symlink( fasta_filename, sym_linked_fasta_filename )


### PR DESCRIPTION
samtools faidx provides a 0 return code when the fasta input file is missing. This will cause the tool to properly enter an error state.