### PR TITLE
Add more environment variables to libxml2

### DIFF
--- a/packages/package_libxml2_2_9_1/tool_dependencies.xml
+++ b/packages/package_libxml2_2_9_1/tool_dependencies.xml
@@ -8,6 +8,10 @@
                 <action type="set_environment">
                     <environment_variable name="PKG_CONFIG_PATH" action="prepend_to">$INSTALL_DIR/lib/pkgconfig</environment_variable>
                     <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>
+                    <environment_variable name="LD_LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/lib</environment_variable>
+                    <environment_variable name="LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/lib</environment_variable>
+                    <environment_variable name="C_INCLUDE_PATH" action="prepend_to">$INSTALL_DIR/include</environment_variable>
+                    <environment_variable name="CPLUS_INCLUDE_PATH" action="prepend_to">$INSTALL_DIR/include</environment_variable>
                 </action>
             </actions>
         </install>


### PR DESCRIPTION
I had trouble using libxml2 from my blast2html tool which is written in python. Currently I'm using a private fork of package_libxml2_2_9_1 but I would prefer to use the mainline one. 

The changes are setting LD_LIBRARY_PATH, LIBRARY_PATH, C_INCLUDE_PATH and CPLUS_INCLUDE_PATH. That allows pip to find the right location of the binary and headers to install the lxml module in the venv that my tool builds.