### PR TITLE
bwa - fixing malformed header because of readgroups

### DIFF
--- a/tools/bwa/bwa-mem.xml
+++ b/tools/bwa/bwa-mem.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="bwa_mem" name="Map with BWA-MEM" version="0.3">
+<tool id="bwa_mem" name="Map with BWA-MEM" version="0.4">
   <description>- map medium and long reads (&gt; 100 bp) against reference genome</description>
   <macros>
     <import>read_group_macros.xml</import>

--- a/tools/bwa/bwa.xml
+++ b/tools/bwa/bwa.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="bwa" name="Map with BWA" version="0.3.0">
+<tool id="bwa" name="Map with BWA" version="0.4.0">
   <description>- map short reads (&lt; 100 bp) against reference genome</description>
   <macros>
     <import>read_group_macros.xml</import>

--- a/tools/bwa/bwa_macros.xml
+++ b/tools/bwa/bwa_macros.xml
@@ -1,18 +1,18 @@
 <macros>
   <import>read_group_macros.xml</import>
   <token name="@set_rg_string@">
-      #set $rg_string = "@RG\tID:" + str($rg_id)
-      #set $rg_string += $format_read_group("\tSM:", $rg_sm)
-      #set $rg_string += $format_read_group("\tPL:", $rg_pl)
-      #set $rg_string += $format_read_group("\tLB:", $rg_lb)
-      #set $rg_string += $format_read_group("\tCN:", $rg_cn)
-      #set $rg_string += $format_read_group("\tDS:", $rg_ds)
-      #set $rg_string += $format_read_group("\tDT:", $rg_dt)
-      #set $rg_string += $format_read_group("\tFO:", $rg_fo)
-      #set $rg_string += $format_read_group("\tKS:", $rg_ks)
-      #set $rg_string += $format_read_group("\tPG:", $rg_pg)
-      #set $rg_string += $format_read_group("\tPI:", $rg_pi)
-      #set $rg_string += $format_read_group("\tPU:", $rg_pu)
+      #set $rg_string = "@RG\\tID:" + str($rg_id)
+      #set $rg_string += $format_read_group("\\tSM:", $rg_sm)
+      #set $rg_string += $format_read_group("\\tPL:", $rg_pl)
+      #set $rg_string += $format_read_group("\\tLB:", $rg_lb)
+      #set $rg_string += $format_read_group("\\tCN:", $rg_cn)
+      #set $rg_string += $format_read_group("\\tDS:", $rg_ds)
+      #set $rg_string += $format_read_group("\\tDT:", $rg_dt)
+      #set $rg_string += $format_read_group("\\tFO:", $rg_fo)
+      #set $rg_string += $format_read_group("\\tKS:", $rg_ks)
+      #set $rg_string += $format_read_group("\\tPG:", $rg_pg)
+      #set $rg_string += $format_read_group("\\tPI:", $rg_pi)
+      #set $rg_string += $format_read_group("\\tPU:", $rg_pu)
   </token>
 
   <xml name="stdio">


### PR DESCRIPTION
the `\t` gets replaced with a real tab and messes up the run/bam file because the `@PG` line gets crappy.
Using `\\t`, like also recommended by bwa [1] fixes this.

[1] http://bio-bwa.sourceforge.net/bwa.shtml