### PR TITLE
Add extra environment vars to libxslt

### DIFF
--- a/packages/package_libxslt_1_1_28/tool_dependencies.xml
+++ b/packages/package_libxslt_1_1_28/tool_dependencies.xml
@@ -16,7 +16,11 @@
                 <action type="shell_command">make &amp;&amp; make install</action>
                 <action type="set_environment">
                   <environment_variable action="prepend_to" name="PKG_CONFIG_PATH">$INSTALL_DIR/lib/pkgconfig</environment_variable>
-                    <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
+                  <environment_variable action="prepend_to" name="PATH">$INSTALL_DIR/bin</environment_variable>
+                  <environment_variable name="LD_LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/lib</environment_variable>
+                  <environment_variable name="LIBRARY_PATH" action="prepend_to">$INSTALL_DIR/lib</environment_variable>
+                  <environment_variable name="C_INCLUDE_PATH" action="prepend_to">$INSTALL_DIR/include</environment_variable>
+                  <environment_variable name="CPLUS_INCLUDE_PATH" action="prepend_to">$INSTALL_DIR/include</environment_variable>
                 </action>
             </actions>
         </install>


### PR DESCRIPTION
This is needed so that python can find the library. LD_LIBRARY_PATH is needed for runtime loading of the lxml module, the others to build the
lxml module correctly.

Without this lxml will build against the system libraries, so everything would appear to work if the libxslt/libxml2 development files are
installed.