### PR TITLE
Fix Bowtie 2 wrapper for unaligned reads for collected pairs.

### DIFF
--- a/tools/bowtie2/bowtie2_wrapper.xml
+++ b/tools/bowtie2/bowtie2_wrapper.xml
@@ -437,17 +437,40 @@
         <data format="fastqsanger" name="output_unaligned_reads_l" label="${tool.name} on ${on_string}: unaligned reads (L)" >
             <filter>library['unaligned_file'] is True</filter>
             <actions>
-                <action type="format">
-                    <option type="from_param" name="library.input_1" param_attribute="ext" />
-                </action>
+                <conditional name="library.type">
+                    <when value="single">
+                        <action type="format">
+                            <option type="from_param" name="library.input_1" param_attribute="ext" />
+                        </action>
+                    </when>
+                    <when value="paired">
+                        <action type="format">
+                            <option type="from_param" name="library.input_1" param_attribute="ext" />
+                        </action>
+                    </when>
+                    <when value="paired_collection">
+                        <action type="format">
+                            <option type="from_param" name="library.input_1" param_attribute="forward.ext" />
+                        </action>
+                    </when>
+                </conditional>
             </actions>
         </data>
         <data format="fastqsanger" name="output_unaligned_reads_r" label="${tool.name} on ${on_string}: unaligned reads (R)">
             <filter>( library['type'] == "paired" or library['type'] == "paired_collection" ) and library['unaligned_file'] is True</filter>
             <actions>
-                <action type="format">
-                    <option type="from_param" name="library.input_1" param_attribute="ext" />
-                </action>
+                <conditional name="library.type">
+                    <when value="paired">
+                        <action type="format">
+                            <option type="from_param" name="library.input_2" param_attribute="ext" />
+                        </action>
+                    </when>
+                    <when value="paired_collection">
+                        <action type="format">
+                            <option type="from_param" name="library.input_1" param_attribute="reverse.ext" />
+                        </action>
+                    </when>
+                </conditional>
             </actions>
         </data>
         


### PR DESCRIPTION
Closes #97 but requires updates to galaxy (specifically see galaxyproject/galaxy#544).

Do we hate the syntax or does it look fine - the conditional outputs aren't new (I found uses of them in gatk for instance) - the new stuff is digging into the collection using the XML attributes.