### PR TITLE
Update download urls for cufflinks source code

### DIFF
--- a/packages/package_cufflinks_2_1_1/tool_dependencies.xml
+++ b/packages/package_cufflinks_2_1_1/tool_dependencies.xml
@@ -27,7 +27,7 @@
                     <package name="eigen" version="3.2.0">
                         <repository name="package_eigen_3_2_0" owner="devteam"  prior_installation_required="True" />
                     </package>
-                    <action type="download_by_url">http://cufflinks.cbcb.umd.edu/downloads/cufflinks-2.1.1.tar.gz</action>
+                    <action type="download_by_url">http://cole-trapnell-lab.github.io/cufflinks/assets/downloads/cufflinks-2.1.1.tar.gz</action>
                     <action type="set_environment_for_install">
                         <repository name="package_boost_1_53" owner="iuc"  prior_installation_required="True">
                             <package name="boost" version="1.53.0" />

--- a/packages/package_cufflinks_2_2_1/tool_dependencies.xml
+++ b/packages/package_cufflinks_2_2_1/tool_dependencies.xml
@@ -27,7 +27,7 @@
                     <package name="eigen" version="3.2.0">
                         <repository name="package_eigen_3_2_0" owner="devteam" prior_installation_required="True" />
                     </package>
-                    <action type="download_by_url">http://cufflinks.cbcb.umd.edu/downloads/cufflinks-2.2.1.tar.gz</action>
+                    <action type="download_by_url">http://cole-trapnell-lab.github.io/cufflinks/assets/downloads/cufflinks-2.2.1.tar.gz</action>
                     <action type="set_environment_for_install">
                         <repository name="package_boost_1_53" owner="iuc" prior_installation_required="True">
                             <package name="boost" version="1.53.0" />


### PR DESCRIPTION
These are 404:

- http://cufflinks.cbcb.umd.edu/downloads/cufflinks-2.1.1.tar.gz
- http://cufflinks.cbcb.umd.edu/downloads/cufflinks-2.2.1.tar.gz

Only the links for the binary packages had previously been updated, see https://github.com/galaxyproject/tools-devteam/commit/f00c3318751dab6a608688a8706798a27cd883ba (@martenson) and https://github.com/galaxyproject/tools-devteam/commit/804f9e6a17882f1353fe0a82692ca887c5a6e3da (@bgruening)

Found while testing ``planemo dependencies_script`` - see https://github.com/galaxyproject/planemo/pull/310

