### PR TITLE
Update tophat source code URLs

### DIFF
--- a/packages/package_tophat2_2_0_9/tool_dependencies.xml
+++ b/packages/package_tophat2_2_0_9/tool_dependencies.xml
@@ -21,7 +21,7 @@
                   <package name="samtools" version="0.1.18">
                       <repository name="package_samtools_0_1_18" owner="devteam" prior_installation_required="True" />
                     </package>
-                    <action type="download_by_url">http://tophat.cbcb.umd.edu/downloads/tophat-2.0.9.tar.gz</action>
+                    <action type="download_by_url">http://ccb.jhu.edu/software/tophat/downloads/tophat-2.0.9.tar.gz</action>
                     <action type="set_environment_for_install">
                       <repository name="package_samtools_0_1_18" owner="devteam" prior_installation_required="True" />
                     </action>

--- a/packages/package_tophat_1_4_0/tool_dependencies.xml
+++ b/packages/package_tophat_1_4_0/tool_dependencies.xml
@@ -21,7 +21,7 @@
                   <package name="samtools" version="0.1.18">
                       <repository name="package_samtools_0_1_18" owner="devteam" prior_installation_required="True" />
                     </package>
-                    <action type="download_by_url">http://tophat.cbcb.umd.edu/downloads/tophat-1.4.0.tar.gz</action>
+                    <action type="download_by_url">http://ccb.jhu.edu/software/tophat/downloads/tophat-1.4.0.tar.gz</action>
                     <action type="set_environment_for_install">
                       <repository name="package_samtools_0_1_18" owner="devteam" prior_installation_required="True" />
                     </action>


### PR DESCRIPTION
These are 404:

- http://tophat.cbcb.umd.edu/downloads/tophat-1.4.0.tar.gz
- http://tophat.cbcb.umd.edu/downloads/tophat-2.0.9.tar.gz

Note there is a ``tophat-1.4.0.1.tar.gz`` available on http://ccb.jhu.edu/software/tophat/downloads/ which I suspect was a minor Linux fix, but this is not mentioned here: https://ccb.jhu.edu/software/tophat/index.shtml

Found while testing planemo dependencies_script - see galaxyproject/planemo#310
