### PR TITLE
Errror when not using "optional_inputs" flag with 'report_monomorphic flag'

### DIFF
--- a/tools/freebayes/freebayes.xml
+++ b/tools/freebayes/freebayes.xml
@@ -354,7 +354,7 @@
         <param name="reference_allele_selector" type="boolean" truevalue="set" falsevalue="do_not_set" label="Use reference allele?" help="Sets --use-reference-allele and --reference-quality options  " />
         <when value="set">
           <param name="Z" type="boolean" truevalue="-Z" falsevalue="" checked="False" label="Include the reference allele in the analysis as if it is another sample from the same population" help="-Z --use-reference-allele; default=False" />
-          <param name="reference_quality" type="text" size="8" value="100,60" label="Assign mapping quality of MQ (100) to the reference allele at each site and base quality of BQ (60)" help="--reference-quality; default=100,60  " />
+          <param name="reference_quality" type="text" value="100,60" label="Assign mapping quality of MQ (100) to the reference allele at each site and base quality of BQ (60)" help="--reference-quality; default=100,60  " />
         </when>
         <when value="do_not_set">
            <!-- do nothing -->
@@ -457,7 +457,7 @@
         <param name="report_genotype_likelihood_max" type="boolean" truevalue="--report-genotype-likelihood-max" falsevalue="" checked="False" label="Report genotypes using the maximum-likelihood estimate provided from genotype likelihoods." help="--report-genotype-likelihood-max; default=False" />
         <param name="B" type="integer" value="1000" label="Iterate no more than N times during genotyping step" help="-B --genotyping-max-iterations; default=1000." />
         <param name="genotyping_max_banddepth" type="integer" value="6" label="Integrate no deeper than the Nth best genotype by likelihood when genotyping" help="--genotyping-max-banddepth; default=6" />
-        <param name="W" type="text" size="8" value="1,3" label="Integrate all genotype combinations in our posterior space which include no more than N (1) samples with their Mth (3) best data likelihood" help="-W --posterior-integration-limits; default=1,3" />
+        <param name="W" type="text" value="1,3" label="Integrate all genotype combinations in our posterior space which include no more than N (1) samples with their Mth (3) best data likelihood" help="-W --posterior-integration-limits; default=1,3" />
         <param name="N" type="boolean" truevalue="--exclude-unobserved-genotypes" falsevalue="" checked="False" label="Skip sample genotypings for which the sample has no supporting reads" help="-N --exclude-unobserved-genotypes; default=False" />
         <conditional name="genotype_variant_threshold">
           <param name="genotype_variant_threshold_selector" type="boolean" truevalue="set" falsevalue="do_not_set" label="Do you want to to limit posterior integration" help="-S --genotype-variant-threshold" />

--- a/tools/freebayes/freebayes.xml
+++ b/tools/freebayes/freebayes.xml
@@ -81,9 +81,7 @@
  
         #if $options_type.optional_inputs.optional_inputs_selector:
        
-	  #if $options_type.optional_inputs.report_monomorphic
-	    ${options_type.optional_inputs.report_monomorphic}
-	  #end if
+	  ${options_type.optional_inputs.report_monomorphic}
  
           #if $options_type.optional_inputs.output_trace_option:
             --trace "${output_trace}"

--- a/tools/freebayes/freebayes.xml
+++ b/tools/freebayes/freebayes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="freebayes" name="FreeBayes" version="0.4">
+<tool id="freebayes" name="FreeBayes" version="0.4.1">
   <requirements>
     <requirement type="package" version="0_9_20_b040236">freebayes</requirement>
     <requirement type="package" version="0.1.18">samtools</requirement>

--- a/tools/freebayes/freebayes.xml
+++ b/tools/freebayes/freebayes.xml
@@ -80,7 +80,11 @@
     #elif str( $options_type.options_type_selector ) == "full":
  
         #if $options_type.optional_inputs.optional_inputs_selector:
-        
+       
+	  #if $options_type.optional_inputs.report_monomorphic
+	    ${options_type.optional_inputs.report_monomorphic}
+	  #end if
+ 
           #if $options_type.optional_inputs.output_trace_option:
             --trace "${output_trace}"
           #end if
@@ -122,7 +126,6 @@
         
 ## REPORTING
 
-        ${options_type.optional_inputs.report_monomorphic}
 
         #if str( $options_type.reporting.reporting_selector ) == "True":
             --pvar ${options_type.reporting.pvar}
@@ -351,7 +354,7 @@
         <param name="reference_allele_selector" type="boolean" truevalue="set" falsevalue="do_not_set" label="Use reference allele?" help="Sets --use-reference-allele and --reference-quality options  " />
         <when value="set">
           <param name="Z" type="boolean" truevalue="-Z" falsevalue="" checked="False" label="Include the reference allele in the analysis as if it is another sample from the same population" help="-Z --use-reference-allele; default=False" />
-          <param name="reference_quality" type="text" value="100,60" label="Assign mapping quality of MQ (100) to the reference allele at each site and base quality of BQ (60)" help="--reference-quality; default=100,60  " />
+          <param name="reference_quality" type="text" size="8" value="100,60" label="Assign mapping quality of MQ (100) to the reference allele at each site and base quality of BQ (60)" help="--reference-quality; default=100,60  " />
         </when>
         <when value="do_not_set">
            <!-- do nothing -->
@@ -454,7 +457,7 @@
         <param name="report_genotype_likelihood_max" type="boolean" truevalue="--report-genotype-likelihood-max" falsevalue="" checked="False" label="Report genotypes using the maximum-likelihood estimate provided from genotype likelihoods." help="--report-genotype-likelihood-max; default=False" />
         <param name="B" type="integer" value="1000" label="Iterate no more than N times during genotyping step" help="-B --genotyping-max-iterations; default=1000." />
         <param name="genotyping_max_banddepth" type="integer" value="6" label="Integrate no deeper than the Nth best genotype by likelihood when genotyping" help="--genotyping-max-banddepth; default=6" />
-        <param name="W" type="text" value="1,3" label="Integrate all genotype combinations in our posterior space which include no more than N (1) samples with their Mth (3) best data likelihood" help="-W --posterior-integration-limits; default=1,3" />
+        <param name="W" type="text" size="8" value="1,3" label="Integrate all genotype combinations in our posterior space which include no more than N (1) samples with their Mth (3) best data likelihood" help="-W --posterior-integration-limits; default=1,3" />
         <param name="N" type="boolean" truevalue="--exclude-unobserved-genotypes" falsevalue="" checked="False" label="Skip sample genotypings for which the sample has no supporting reads" help="-N --exclude-unobserved-genotypes; default=False" />
         <conditional name="genotype_variant_threshold">
           <param name="genotype_variant_threshold_selector" type="boolean" truevalue="set" falsevalue="do_not_set" label="Do you want to to limit posterior integration" help="-S --genotype-variant-threshold" />


### PR DESCRIPTION
Fixing issue when 'optional_inputs' is not selected and then complain it cannot find 'report_monomorphic'.  parameter. Moved it to be under all other parameter that only show up when 'optional_inputs' is selected.

Example of stacktrace

Traceback (most recent call last):
  File "/Applications/galaxy/production/galaxy-dist/lib/galaxy/jobs/runners/__init__.py", line 163, in prepare_job
    job_wrapper.prepare()
  File "/Applications/galaxy/production/galaxy-dist/lib/galaxy/jobs/__init__.py", line 859, in prepare
    self.command_line, self.extra_filenames, self.environment_variables = tool_evaluator.build()
  File "/Applications/galaxy/production/galaxy-dist/lib/galaxy/tools/evaluation.py", line 422, in build
    raise e
NotFound: cannot find 'report_monomorphic' while searching for 'options_type.optional_inputs.report_monomorphic'