### PR TITLE
add repository dependency to fetch genome data manager

### DIFF
--- a/data_managers/data_manager_bowtie2_index_builder/repository_dependencies.xml
+++ b/data_managers/data_manager_bowtie2_index_builder/repository_dependencies.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<repositories description="Related data managers">
+    <repository name="data_manager_fetch_genome_dbkeys_all_fasta" owner="devteam" />
+</repositories>


### PR DESCRIPTION
@blankenberg do you think this PR is useful? 
I find myself often installing top level data managers (bowtie, bwa) without the underlying ones. A repository dependency could help here.
