### PR TITLE
Remove sort_by for build/indexes

### DIFF
--- a/tools/bowtie2/bowtie2_wrapper.xml
+++ b/tools/bowtie2/bowtie2_wrapper.xml
@@ -268,7 +268,6 @@
           <when value="indexed">
             <param name="index" type="select" label="Select reference genome" help="If your genome of interest is not listed, contact the Galaxy team">
               <options from_data_table="bowtie2_indexes">
-                <filter type="sort_by" column="2"/>
                 <validator type="no_options" message="No indexes are available for the selected input dataset"/>
               </options>
             </param>

--- a/tools/bowtie_color_wrappers/bowtie_color_wrapper.xml
+++ b/tools/bowtie_color_wrappers/bowtie_color_wrapper.xml
@@ -141,7 +141,6 @@
       <when value="indexed">
         <param name="index" type="select" label="Select the reference genome" help="if your genome of interest is not listed - contact Galaxy team">
           <options from_data_table="bowtie_indexes_color">
-            <filter type="sort_by" column="2" />
             <validator type="no_options" message="No indexes are available" />
           </options>
         </param>

--- a/tools/bowtie_wrappers/bowtie_wrapper.xml
+++ b/tools/bowtie_wrappers/bowtie_wrapper.xml
@@ -158,7 +158,6 @@
       <when value="indexed">
         <param name="index" type="select" label="Select a reference genome" help="if your genome of interest is not listed - contact Galaxy team">
           <options from_data_table="bowtie_indexes">
-            <filter type="sort_by" column="2" />
             <validator type="no_options" message="No indexes are available" />
           </options>
         </param>

--- a/tools/bwa/bwa-mem.xml
+++ b/tools/bwa/bwa-mem.xml
@@ -150,7 +150,6 @@
       <when value="cached">
         <param name="ref_file" type="select" label="Using reference genome" help="Select genome from the list">
           <options from_data_table="bwa_mem_indexes">
-            <filter type="sort_by" column="2" />
             <validator type="no_options" message="No indexes are available" />
           </options>
           <validator type="no_options" message="A built-in reference genome is not available for the build associated with the selected input file"/>

--- a/tools/bwa/bwa.xml
+++ b/tools/bwa/bwa.xml
@@ -270,7 +270,6 @@
       <when value="cached">
         <param name="ref_file" type="select" label="Using reference genome" help="Select genome from the list">
           <options from_data_table="bwa_mem_indexes">
-            <filter type="sort_by" column="2" />
             <validator type="no_options" message="No indexes are available" />
           </options>
           <validator type="no_options" message="A built-in reference genome is not available for the build associated with the selected input file"/>

--- a/tools/hisat/hisat.xml
+++ b/tools/hisat/hisat.xml
@@ -103,7 +103,6 @@
             <when value="indexed">
                 <param name="index" type="select" label="Select a reference genome" help="If your genome of interest is not listed, contact the Galaxy team">
                     <options from_data_table="hisat_indexes">
-                        <filter type="sort_by" column="2"/>
                         <validator type="no_options" message="No genomes are available for the selected input dataset"/>
                     </options>
                 </param>

--- a/tools/picard/picard_BedToIntervalList.xml
+++ b/tools/picard/picard_BedToIntervalList.xml
@@ -48,7 +48,6 @@
       <when value="cached">
         <param name="ref_file" type="select" label="Use dictionary from the list" help="Select genome from the list">
           <options from_data_table="picard_indexes">
-            <filter type="sort_by" column="2" />
             <validator type="no_options" message="No indexes are available" />
           </options>
           <validator type="no_options" message="A built-in dictionary is not available for the build associated with the selected input file"/>

--- a/tools/picard/picard_MergeBamAlignment.xml
+++ b/tools/picard/picard_MergeBamAlignment.xml
@@ -97,7 +97,6 @@
       <when value="cached">
         <param name="ref_file" type="select" label="Use dictionary from the list" help="Select genome from the list">
           <options from_data_table="picard_indexes">
-            <filter type="sort_by" column="2" />
             <validator type="no_options" message="No indexes are available" />
           </options>
           <validator type="no_options" message="A built-in dictionary is not available for the build associated with the selected input file"/>

--- a/tools/picard/picard_ReorderSam.xml
+++ b/tools/picard/picard_ReorderSam.xml
@@ -49,7 +49,6 @@
       <when value="cached">
         <param name="ref_file" type="select" label="Use dictionary from the list" help="Select genome from the list">
           <options from_data_table="picard_indexes">
-            <filter type="sort_by" column="2" />
             <validator type="no_options" message="No indexes are available" />
           </options>
           <validator type="no_options" message="A built-in dictionary is not available for the build associated with the selected input file"/>

--- a/tools/picard/picard_ValidateSamFile.xml
+++ b/tools/picard/picard_ValidateSamFile.xml
@@ -57,7 +57,6 @@
       <when value="cached">
         <param name="ref_file" type="select" label="Use dictionary from the list" help="Select genome from the list">
           <options from_data_table="picard_indexes">
-            <filter type="sort_by" column="2" />
             <validator type="no_options" message="No indexes are available" />
           </options>
           <validator type="no_options" message="A built-in dictionary is not available for the build associated with the selected input file"/>

--- a/tools/tophat/tophat_wrapper.xml
+++ b/tools/tophat/tophat_wrapper.xml
@@ -154,7 +154,6 @@
         <param format="fastqsanger" name="input1" type="data" label="RNA-Seq FASTQ file" help="Nucleotide-space: Must have Sanger-scaled quality values with ASCII offset 33" />
         <expand macro="refGenomeSourceConditional">
           <options from_data_table="tophat_indexes">
-            <filter type="sort_by" column="2"/>
             <validator type="no_options" message="No genomes are available for the selected input dataset"/>
           </options>
         </expand>

--- a/tools/tophat2/tophat2_wrapper.xml
+++ b/tools/tophat2/tophat2_wrapper.xml
@@ -150,7 +150,6 @@
         </conditional>
         <expand macro="refGenomeSourceConditional">
           <options from_data_table="tophat2_indexes">
-            <filter type="sort_by" column="2"/>
             <validator type="no_options" message="No genomes are available for the selected input dataset"/>
           </options>
         </expand>


### PR DESCRIPTION
If you guys think this is a good idea this removes sort_by from all tools (except for legacy/bwa).
Relates: #251 