### PR TITLE
Add option to Bowtie & Bowtie2 to keep statistics from stderr

### DIFF
--- a/tools/bowtie2/bowtie2_wrapper.xml
+++ b/tools/bowtie2/bowtie2_wrapper.xml
@@ -435,7 +435,7 @@
                 <param name="sam_opt" type="boolean" truevalue="true" falsevalue="false" label="Would you like the output to be a SAM file" help="By default, the output from this Bowtie2 wrapper is a sorted BAM file."/>
             </when>
         </conditional>
-        <param name="save_mapping_stats" type="boolean" truevalue="True" falsevalue="False" checked="False" label="Save the bowtie2 mapping statistics to the history" />
+        <param name="save_mapping_stats" type="boolean" checked="False" label="Save the bowtie2 mapping statistics to the history" />
     </inputs>
 
     <!-- define outputs -->

--- a/tools/bowtie2/bowtie2_wrapper.xml
+++ b/tools/bowtie2/bowtie2_wrapper.xml
@@ -167,6 +167,11 @@
             ${analysis_type.cline}
         #end if
 
+        ## mapping stats (i.e. stderr from bowtie2)
+        #if $save_mapping_stats
+	  2&gt; "$mapping_stats"
+        #end if
+
         ## output file
         #if ( str( $analysis_type.analysis_type_selector ) != "full" or str( $analysis_type.sam_opt ) != "true" ):
           | samtools view -Su - | samtools sort -o - - &gt; $output
@@ -430,6 +435,7 @@
                 <param name="sam_opt" type="boolean" truevalue="true" falsevalue="false" label="Would you like the output to be a SAM file" help="By default, the output from this Bowtie2 wrapper is a sorted BAM file."/>
             </when>
         </conditional>
+        <param name="save_mapping_stats" type="boolean" truevalue="True" falsevalue="False" checked="False" label="Save the bowtie2 mapping statistics to the history" />
     </inputs>
 
     <!-- define outputs -->
@@ -517,6 +523,9 @@
             </conditional>
           </actions>
         </data>
+        <data format="txt" name="mapping_stats" label="${tool.name} on ${on_string}: mapping stats">
+          <filter>save_mapping_stats is True</filter>
+        </data>
 
     </outputs>
 
@@ -549,6 +558,21 @@
             <param name="input_2" value="bowtie2-fq2.fq" ftype="fastqsanger"/>
             <param name="own_file" value="bowtie2-ref.fasta" />
             <output name="output" file="bowtie2-test2.bam" ftype="bam" lines_diff="2"/>
+        </test>
+        <test>
+            <!-- basic test on single paired default run with stats-->
+            <param name="type" value="paired"/>
+            <param name="selection" value="no"/>
+            <param name="paired_options_selector" value="no"/>
+            <param name="unaligned_file" value="false"/>
+            <param name="analysis_type_selector" value="simple"/>
+            <param name="source" value="history" />
+            <param name="input_1" value="bowtie2-fq1.fq" ftype="fastqsanger"/>
+            <param name="input_2" value="bowtie2-fq2.fq" ftype="fastqsanger"/>
+            <param name="own_file" value="bowtie2-ref.fasta" />
+            <param name="save_mapping_stats" value="true" />
+            <output name="output" file="bowtie2-test1.bam" ftype="bam" lines_diff="2"/>
+            <output name="mapping_stats" file="bowtie2-stats.out" ftype="txt"/>
         </test>
     </tests>
 

--- a/tools/bowtie2/bowtie2_wrapper.xml
+++ b/tools/bowtie2/bowtie2_wrapper.xml
@@ -1,4 +1,4 @@
-<tool id="bowtie2" name="Bowtie2" version="2.2.6">
+<tool id="bowtie2" name="Bowtie2" version="2.2.6.1">
     <description>- map reads against reference genome</description>
     <macros>
         <import>read_group_macros.xml</import>

--- a/tools/bowtie2/test-data/bowtie2-stats.out
+++ b/tools/bowtie2/test-data/bowtie2-stats.out
@@ -1,0 +1,15 @@
+100 reads; of these:
+  100 (100.00%) were paired; of these:
+    97 (97.00%) aligned concordantly 0 times
+    3 (3.00%) aligned concordantly exactly 1 time
+    0 (0.00%) aligned concordantly >1 times
+    ----
+    97 pairs aligned concordantly 0 times; of these:
+      8 (8.25%) aligned discordantly 1 time
+    ----
+    89 pairs aligned 0 times concordantly or discordantly; of these:
+      178 mates make up the pairs; of these:
+        153 (85.96%) aligned 0 times
+        25 (14.04%) aligned exactly 1 time
+        0 (0.00%) aligned >1 times
+23.50% overall alignment rate

--- a/tools/bowtie_wrappers/bowtie_wrapper.py
+++ b/tools/bowtie_wrappers/bowtie_wrapper.py
@@ -436,9 +436,8 @@ def __main__():
                 raise Exception, stderr
             elif options.output_mapping_stats is not None:
                 # Write stderr (containing the mapping statistics) to a named file
-                mapping_stats = open( options.output_mapping_stats, 'w')
-                mapping_stats.write( stderr )
-                mapping_stats.close()
+                with open(options.output_mapping_stats, 'w') as mapping_stats:
+                    mapping_stats.write( stderr )
             # get suppressed and unmapped reads output files in place if appropriate
             if options.paired == 'paired' and tmp_suppressed_file_name and \
                                options.output_suppressed_reads_l and options.output_suppressed_reads_r:

--- a/tools/bowtie_wrappers/bowtie_wrapper.py
+++ b/tools/bowtie_wrappers/bowtie_wrapper.py
@@ -13,6 +13,7 @@ usage: bowtie_wrapper.py [options]
     --output_suppressed_reads=: File name for suppressed reads because of max setting (single-end)
     --output_suppressed_reads_l=: File name for suppressed reads because of max setting (left, paired-end)
     --output_suppressed_reads_r=: File name for suppressed reads because of max setting (right, paired-end)
+    --output_mapping_stats=: File name for mapping statistics (output on stderr by bowtie)
     -i, --input1=i: The (forward or single-end) reads file in Sanger FASTQ format
     -I, --input2=I: The reverse reads file in Sanger FASTQ format
     -4, --dataType=4: The type of data (SOLiD or Solexa)
@@ -86,6 +87,7 @@ def __main__():
     parser.add_option( '', '--output_suppressed_reads', dest='output_suppressed_reads', help='File name for suppressed reads because of max setting (single-end)' )
     parser.add_option( '', '--output_suppressed_reads_l', dest='output_suppressed_reads_l', help='File name for suppressed reads because of max setting (left, paired-end)' )
     parser.add_option( '', '--output_suppressed_reads_r', dest='output_suppressed_reads_r', help='File name for suppressed reads because of max setting (right, paired-end)' )
+    parser.add_option( '', '--output_mapping_stats', dest='output_mapping_stats', help='File for mapping statistics (i.e. stderr from bowtie)' )
     parser.add_option( '-4', '--dataType', dest='dataType', help='The type of data (SOLiD or Solexa)' )
     parser.add_option( '-i', '--input1', dest='input1', help='The (forward or single-end) reads file in Sanger FASTQ format' )
     parser.add_option( '-I', '--input2', dest='input2', help='The reverse reads file in Sanger FASTQ format' )
@@ -415,7 +417,7 @@ def __main__():
             # align
             tmp = tempfile.NamedTemporaryFile( dir=tmp_index_dir ).name
             tmp_stderr = open( tmp, 'wb' )
-            proc = subprocess.Popen( args=cmd2, shell=True, cwd=tmp_index_dir, stderr=tmp_stderr.fileno() )
+            proc = subprocess.Popen( args=cmd2, shell=True, cwd=tmp_index_dir, stdout=sys.stdout, stderr=tmp_stderr.fileno() )
             returncode = proc.wait()
             tmp_stderr.close()
             # get stderr, allowing for case where it's very large
@@ -432,6 +434,11 @@ def __main__():
             tmp_stderr.close()
             if returncode != 0:
                 raise Exception, stderr
+            elif options.output_mapping_stats is not None:
+                # Write stderr (containing the mapping statistics) to a named file
+                mapping_stats = open( options.output_mapping_stats, 'w')
+                mapping_stats.write( stderr )
+                mapping_stats.close()
             # get suppressed and unmapped reads output files in place if appropriate
             if options.paired == 'paired' and tmp_suppressed_file_name and \
                                options.output_suppressed_reads_l and options.output_suppressed_reads_r:

--- a/tools/bowtie_wrappers/bowtie_wrapper.xml
+++ b/tools/bowtie_wrappers/bowtie_wrapper.xml
@@ -1,4 +1,4 @@
-<tool id="bowtie_wrapper" name="Map with Bowtie for Illumina" version="1.1.3">
+<tool id="bowtie_wrapper" name="Map with Bowtie for Illumina" version="1.1.4">
   <requirements>
     <requirement type="package" version="0.12.7">bowtie</requirement>
   </requirements>

--- a/tools/bowtie_wrappers/bowtie_wrapper.xml
+++ b/tools/bowtie_wrappers/bowtie_wrapper.xml
@@ -148,6 +148,9 @@
           --seed="${singlePaired.pParams.pSeed}"
         #end if
       #end if
+      #if $save_mapping_stats
+        --output_mapping_stats="$mapping_stats"
+      #end if
   </command>
   <inputs>
     <conditional name="refGenomeSource">
@@ -415,6 +418,7 @@
         </conditional> <!-- pParams -->
       </when> <!-- paired -->
     </conditional> <!-- singlePaired -->
+    <param name="save_mapping_stats" type="boolean" truevalue="True" falsevalue="False" checked="False" label="Save the bowtie mapping statistics to the history" />
     <param name="suppressHeader" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Suppress the header in the output SAM file (--sam-nohead)" help="Bowtie produces SAM with several lines of header information by default" />
   </inputs>
   <outputs>
@@ -436,6 +440,9 @@
           </when>
         </conditional>
       </actions>
+    </data>
+    <data format="txt" name="mapping_stats" label="${tool.name} on ${on_string}: mapping stats">
+      <filter>save_mapping_stats is True</filter>
     </data>
     <data format="fastq" name="output_suppressed_reads_l" label="${tool.name} on ${on_string}: suppressed reads (L)">
       <filter>((
@@ -743,6 +750,37 @@
       <param name="pSettingsType" value="preSet" />
       <param name="suppressHeader" value="true" />
       <output name="output" ftype="sam" file="bowtie_out10.sam" sort="True" />
+    </test>
+    <test>
+      <!--
+      Bowtie command:
+      bowtie-build +offrate 5 +ftabchars 10 +little -f test-data/phiX.fasta phiX_base
+      bowtie -q -X 1000 +ff -p 4 -S +sam-nohead phiX_base -1 test-data/bowtie_in5.fastqsanger -2 test-data/bowtie_in6.fastqsanger > bowtie_out10_u.sam
+      sort bowtie_out10_u.sam > bowtie_out10.sam
+      -p is the number of threads. You need to replace the + with 2 dashes.
+      chrM_base is the index files' location/base name.
+      -->
+      <param name="genomeSource" value="history" />
+      <param name="ownFile" value="phiX.fasta" />
+      <param name="indexSettings" value="indexFull" />
+      <param name="autoB" value="auto" />
+      <param name="nodc" value="dc" />
+      <param name="noref" value="ref" />
+      <param name="offrate" value="5" />
+      <param name="ftab" value="10" />
+      <param name="ntoa" value="no" />
+      <param name="endian" value="little" />
+      <param name="seed" value="-1" />
+      <param name="sPaired" value="paired" />
+      <param name="pInput1" ftype="fastqsanger" value="bowtie_in5.fastqsanger" />
+      <param name="pInput2" ftype="fastqsanger" value="bowtie_in6.fastqsanger" />
+      <param name="pMaxInsert" value="1000" />
+      <param name="pMateOrient" value="ff" />
+      <param name="pSettingsType" value="preSet" />
+      <param name="suppressHeader" value="true" />
+      <param name="save_mapping_stats" value="true" />
+      <output name="output" ftype="sam" file="bowtie_out10.sam" sort="True" />
+      <output name="mapping_stats" ftype="txt" file="bowtie_out11.txt" sort="True" />
     </test>
   </tests>
 

--- a/tools/bowtie_wrappers/bowtie_wrapper.xml
+++ b/tools/bowtie_wrappers/bowtie_wrapper.xml
@@ -418,7 +418,7 @@
         </conditional> <!-- pParams -->
       </when> <!-- paired -->
     </conditional> <!-- singlePaired -->
-    <param name="save_mapping_stats" type="boolean" truevalue="True" falsevalue="False" checked="False" label="Save the bowtie mapping statistics to the history" />
+    <param name="save_mapping_stats" type="boolean" checked="False" label="Save the bowtie mapping statistics to the history" />
     <param name="suppressHeader" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Suppress the header in the output SAM file (--sam-nohead)" help="Bowtie produces SAM with several lines of header information by default" />
   </inputs>
   <outputs>

--- a/tools/bowtie_wrappers/test-data/bowtie_out11.txt
+++ b/tools/bowtie_wrappers/test-data/bowtie_out11.txt
@@ -1,0 +1,4 @@
+# reads processed: 18
+# reads with at least one reported alignment: 13 (72.22%)
+# reads that failed to align: 5 (27.78%)
+Reported 13 paired-end alignments to 1 output stream(s)


### PR DESCRIPTION
By default the `bowtie_wrapper` and `bowtie2` tools don't keep the stderr output from the underlying `bowtie` and `bowtie2` programs, however this contains useful statistics on the mapping.

This PR adds an option to both tools that, when selected, saves these statistics as a history item when the tools are run. (There are also new test cases, however I haven't been able to get these or the existing tests to pass.)

Adding this functionality has previously been discussed on this Trello card:

https://trello.com/c/TdYxdbkm

which also contains my original patch for the`bowtie_wrapper`. I've returned to this now I have users who are interested in having this functionality in our local Galaxy instance, however the thread on Trello suggests that others might also find it useful.

Thanks for considering these changes, all feedback welcome.