### PR TITLE
added --quiet to suppress progress bar, filling up logs

### DIFF
--- a/tool_collections/cufflinks/cuffdiff/cuffdiff_wrapper.xml
+++ b/tool_collections/cufflinks/cuffdiff/cuffdiff_wrapper.xml
@@ -13,6 +13,7 @@
     <command><![CDATA[
         cuffdiff
             --no-update-check
+            --quiet
             --FDR=$fdr
             --num-threads="\${GALAXY_SLOTS:-4}"
             --min-alignment-count=$min_alignment_count


### PR DESCRIPTION
--quiet is not implemented, this causes progress bar output to be dumped into log data.  It is implemented elsewhere, for example line 107 here:

https://github.com/galaxyproject/tools-devteam/blob/master/tool_collections/cufflinks/cufflinks/cufflinks_wrapper.py#L107