### PR TITLE
Fix the BWA tools to require version 0.7.12 of the BWA package.

### DIFF
--- a/tools/bwa/.shed.yml
+++ b/tools/bwa/.shed.yml
@@ -2,7 +2,7 @@ categories:
 - Next Gen Mappers
 description: 'Wrapper for bwa mem, aln, sampe, and samse'
 long_description: |
-  A collection of Galaxy bwa wrappers based on version 0.7.10 (039ea206392ada2542bc41ff2581c53fa2fe2bf2).
+  A collection of Galaxy bwa wrappers based on version 0.7.12.
 name: bwa
 owner: devteam
 remote_repository_url: https://github.com/galaxyproject/tools-devteam/tree/master/tools/bwa

--- a/tools/bwa/bwa-mem.xml
+++ b/tools/bwa/bwa-mem.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="bwa_mem" name="Map with BWA-MEM" version="0.4.1">
+<tool id="bwa_mem" name="Map with BWA-MEM" version="0.4.2">
   <description>- map medium and long reads (&gt; 100 bp) against reference genome</description>
   <macros>
     <import>read_group_macros.xml</import>

--- a/tools/bwa/bwa.xml
+++ b/tools/bwa/bwa.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="bwa" name="Map with BWA" version="0.4.1">
+<tool id="bwa" name="Map with BWA" version="0.4.2">
   <description>- map short reads (&lt; 100 bp) against reference genome</description>
   <macros>
     <import>read_group_macros.xml</import>

--- a/tools/bwa/bwa_macros.xml
+++ b/tools/bwa/bwa_macros.xml
@@ -17,7 +17,7 @@
 
   <xml name="requirements">
     <requirements>
-      <requirement type="package" version="0.7.10.039ea20639">bwa</requirement>
+      <requirement type="package" version="0.7.12">bwa</requirement>
       <requirement type="package" version="1.2">samtools</requirement>
     </requirements>
   </xml>

--- a/tools/bwa/tool_dependencies.xml
+++ b/tools/bwa/tool_dependencies.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <tool_dependency>
-    <package name="bwa" version="0.7.10.039ea20639">
-        <repository name="package_bwa_0_7_10_039ea20639" owner="devteam" />
+    <package name="bwa" version="0.7.12">
+        <repository name="package_bwa_0_7_12" owner="iuc" />
     </package>
     <package name="samtools" version="1.2">
         <repository name="package_samtools_1_2" owner="iuc" />


### PR DESCRIPTION
The versions of these tools have been updated to be 0.4.2.