### PR TITLE
Fail the job if bwa index fails.

### DIFF
--- a/tools/bwa/bwa-mem.xml
+++ b/tools/bwa/bwa-mem.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="bwa_mem" name="Map with BWA-MEM" version="0.4.2">
+<tool id="bwa_mem" name="Map with BWA-MEM" version="0.7.12">
   <description>- map medium and long reads (&gt; 100 bp) against reference genome</description>
   <macros>
     <import>read_group_macros.xml</import>
@@ -8,41 +8,26 @@
   <expand macro="requirements" />
   <expand macro="stdio" />
   <command>
+<![CDATA[
     #set $reference_fasta_filename = "localref.fa"
 
     #if str( $reference_source.reference_source_selector ) == "history":
-        ln -s "${reference_source.ref_file}" "${reference_fasta_filename}" &amp;&amp;
+        ln -s "${reference_source.ref_file}" "${reference_fasta_filename}" &&
 
-        ## The following shell commands decide with of the BWA indexing algorithms (IS or BWTSW) will be run
-        ## depending ob the size of the input FASTA dataset
-           (
-            size=`stat -c %s "${reference_fasta_filename}" 2&gt;/dev/null`;                  ## Linux
-            if [ $? -eq 0 ];
-            then
-              if [ "\$size" -lt 2000000000 ];
-              then
-                bwa index -a is "${reference_fasta_filename}";
-                echo "Generating BWA index with is algorithm";
-              else
-                bwa index -a bwtsw "${reference_fasta_filename}";
-                echo "Generating BWA index with bwtsw algorithm";
-              fi;
-            fi;
-
-            eval \$(stat -s "${reference_fasta_filename}" 2&gt;/dev/null);                   ## OSX
-            if [ -n "\$st_size" ];
-            then
-              if [ "\$st_size" -lt 2000000000 ];
-              then
-                bwa index -a is "${reference_fasta_filename}";
-                echo "Generating BWA index with is algorithm";
-              else
-                bwa index -a bwtsw "${reference_fasta_filename}";
-                echo "Generating BWA index with bwtsw algorithm";
-              fi;
-            fi;
-            ) &amp;&amp;
-
+        ## The following shell commands decide which of the BWA indexing algorithms (IS or BWTSW) will be run
+        ## depending on the size of the input FASTA dataset
+        ( size=`stat -c %s "${reference_source.ref_file}" 2>/dev/null`; ## Linux
+          if [ $? -ne 0 ]; then
+              size=\$(stat -f %z "${reference_source.ref_file}"); ## OSX
+          fi &&
+          if [ "\$size" -lt 2000000000 ]; then
+              echo "Reference genome size is \$size bytes, generating BWA index with is algorithm";
+              bwa index -a is "${reference_fasta_filename}";
+          else
+              echo "Reference genome size is \$size bytes, generating BWA index with bwtsw algorithm";
+              bwa index -a bwtsw "${reference_fasta_filename}";
+          fi
+        ) &&
     #else:
         #set $reference_fasta_filename = str( $reference_source.ref_file.fields.path )
     #end if
@@ -132,9 +117,10 @@
       "${fastq_input.fastq_input1}"
     #end if
 
-    | samtools view -Sb - > temporary_bam_file.bam &amp;&amp;
+    | samtools view -Sb - > temporary_bam_file.bam &&
 
     samtools sort -f temporary_bam_file.bam ${bam_output}
+]]>
   </command>
 
   <inputs>

--- a/tools/bwa/bwa.xml
+++ b/tools/bwa/bwa.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="bwa" name="Map with BWA" version="0.4.2">
+<tool id="bwa" name="Map with BWA" version="0.7.12">
   <description>- map short reads (&lt; 100 bp) against reference genome</description>
   <macros>
     <import>read_group_macros.xml</import>
@@ -68,38 +68,26 @@
   <expand macro="requirements" />
   <expand macro="stdio" />
   <command>
+<![CDATA[
     #set $reference_fasta_filename = "localref.fa"
 
     #if str( $reference_source.reference_source_selector ) == "history":
-        ln -s "${reference_source.ref_file}" "${reference_fasta_filename}" &amp;&amp;
+        ln -s "${reference_source.ref_file}" "${reference_fasta_filename}" &&
 
-        ## The following shell commands decide with of the BWA indexing algorithms (IS or BWTSW) will be run
-        ## depending ob the size of the input FASTA dataset
-           (
-            size=`stat -c %s "${reference_fasta_filename}" 2&gt;/dev/null`;                  ## Linux
-            if [ $? -eq 0 ];
-            then
-              if [ "\$size" -lt 2000000000 ];
-              then
-                bwa index -a is "${reference_fasta_filename}";
-              else
-                bwa index -a bwtsw "${reference_fasta_filename}";
-              fi;
-            fi;
-
-            eval \$(stat -s "${reference_fasta_filename}" 2&gt;/dev/null);                   ## OSX
-            if [ -n "\$st_size" ];
-            then
-              if [ "\$st_size" -lt 2000000000 ];
-              then
-                bwa index -a is "${reference_fasta_filename}";
-                echo "Generating BWA index with is algorithm";
-              else
-                bwa index -a bwtsw "${reference_fasta_filename}";
-                echo "Generating BWA index with bwtsw algorithm";
-              fi;
-            fi;
-            ) &amp;&amp;
+        ## The following shell commands decide which of the BWA indexing algorithms (IS or BWTSW) will be run
+        ## depending on the size of the input FASTA dataset
+        ( size=`stat -c %s "${reference_source.ref_file}" 2>/dev/null`; ## Linux
+          if [ $? -ne 0 ]; then
+              size=\$(stat -f %z "${reference_source.ref_file}"); ## OSX
+          fi &&
+          if [ "\$size" -lt 2000000000 ]; then
+              echo "Reference genome size is \$size bytes, generating BWA index with is algorithm";
+              bwa index -a is "${reference_fasta_filename}";
+          else
+              echo "Reference genome size is \$size bytes, generating BWA index with bwtsw algorithm";
+              bwa index -a bwtsw "${reference_fasta_filename}";
+          fi
+        ) &&
     #else:
         #set $reference_fasta_filename = str( $reference_source.ref_file.fields.path )
     #end if
@@ -134,7 +122,7 @@
         "${input_type.fastq_input1}"
       #end if
 
-      > first.sai &amp;&amp;
+      > first.sai &&
 
       bwa aln
       -t "\${GALAXY_SLOTS:-1}"
@@ -149,7 +137,7 @@
         "${input_type.fastq_input2}"
       #end if
 
-      > second.sai &amp;&amp;
+      > second.sai &&
 
       bwa sampe
 
@@ -178,7 +166,7 @@
 
       "${reference_fasta_filename}"
       "${input_type.fastq_input1}"
-      > first.sai &amp;&amp;
+      > first.sai &&
 
       bwa samse
 
@@ -202,7 +190,7 @@
 
       "${reference_fasta_filename}"
       "${input_type.bam_input}"
-      > first.sai &amp;&amp;
+      > first.sai &&
 
       bwa aln
       -t "\${GALAXY_SLOTS:-1}"
@@ -211,7 +199,7 @@
       @command_options@
       "${reference_fasta_filename}"
       "${input_type.bam_input}"
-      > second.sai &amp;&amp;
+      > second.sai &&
 
       bwa sampe
 
@@ -238,7 +226,7 @@
 
       "${reference_fasta_filename}"
       "${input_type.bam_input}"
-      > first.sai &amp;&amp;
+      > first.sai &&
 
       bwa samse
 
@@ -251,9 +239,10 @@
       "${reference_fasta_filename}" first.sai "${input_type.bam_input}"
     #end if
 
-    | samtools view -Sb - > temporary_bam_file.bam &amp;&amp;
+    | samtools view -Sb - > temporary_bam_file.bam &&
 
     samtools sort -f temporary_bam_file.bam ${bam_output}
+]]>
   </command>
 
   <inputs>


### PR DESCRIPTION
Also use CDATA in `<command>`.

Partially fix #312.

Testing by an OS X user would be appreciated.