### PR TITLE
BWA: Add param for reference indexing algorithm.

### DIFF
--- a/tools/bwa/bwa-mem.xml
+++ b/tools/bwa/bwa-mem.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="bwa_mem" name="Map with BWA-MEM" version="0.7.12">
+<tool id="bwa_mem" name="Map with BWA-MEM" version="@VERSION@.1">
   <description>- map medium and long reads (&gt; 100 bp) against reference genome</description>
   <macros>
     <import>read_group_macros.xml</import>
@@ -9,28 +9,7 @@
   <expand macro="stdio" />
   <command>
 <![CDATA[
-    #set $reference_fasta_filename = "localref.fa"
-
-    #if str( $reference_source.reference_source_selector ) == "history":
-        ln -s "${reference_source.ref_file}" "${reference_fasta_filename}" &&
-
-        ## The following shell commands decide which of the BWA indexing algorithms (IS or BWTSW) will be run
-        ## depending on the size of the input FASTA dataset
-        ( size=`stat -c %s "${reference_source.ref_file}" 2>/dev/null`; ## Linux
-          if [ $? -ne 0 ]; then
-              size=\$(stat -f %z "${reference_source.ref_file}"); ## OSX
-          fi &&
-          if [ "\$size" -lt 2000000000 ]; then
-              echo "Reference genome size is \$size bytes, generating BWA index with is algorithm";
-              bwa index -a is "${reference_fasta_filename}";
-          else
-              echo "Reference genome size is \$size bytes, generating BWA index with bwtsw algorithm";
-              bwa index -a bwtsw "${reference_fasta_filename}";
-          fi
-        ) &&
-    #else:
-        #set $reference_fasta_filename = str( $reference_source.ref_file.fields.path )
-    #end if
+    @set_reference_fasta_filename@
 
     ## Begin BWA-MEM command line
 
@@ -124,25 +103,7 @@
   </command>
 
   <inputs>
-
-    <conditional name="reference_source">
-      <param name="reference_source_selector" type="select" label="Will you select a reference genome from your history or use a built-in index?" help="Built-ins were indexed using default options. See `Indexes` section of help below">
-        <option value="cached">Use a built-in genome index</option>
-        <option value="history">Use a genome from history and build index</option>
-      </param>
-      <when value="cached">
-        <param name="ref_file" type="select" label="Using reference genome" help="Select genome from the list">
-          <options from_data_table="bwa_mem_indexes">
-            <filter type="sort_by" column="2" />
-            <validator type="no_options" message="No indexes are available" />
-          </options>
-          <validator type="no_options" message="A built-in reference genome is not available for the build associated with the selected input file"/>
-        </param>
-      </when>
-      <when value="history">
-        <param name="ref_file" type="data" format="fasta" label="Use the following dataset as the reference sequence" help="You can upload a FASTA sequence to the history and use it as reference" />
-      </when>
-    </conditional>
+    <expand macro="reference_source_conditional" />
     <conditional name="fastq_input">
       <param name="fastq_input_selector" type="select" label="Single or Paired-end reads" help="Select between paired and single end data">
         <option value="paired">Paired</option>
@@ -290,6 +251,7 @@
     <test>
       <param name="reference_source_selector" value="history" />
       <param name="ref_file" ftype="fasta" value="bwa-mem-mt-genome.fa"/>
+      <param name="index_a" value="is"/>
       <param name="fastq_input_selector" value="paired"/>
       <param name="fastq_input1" ftype="fastqsanger" value="bwa-mem-fastq1.fq"/>
       <param name="fastq_input2" ftype="fastqsanger" value="bwa-mem-fastq2.fq"/>

--- a/tools/bwa/bwa.xml
+++ b/tools/bwa/bwa.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="bwa" name="Map with BWA" version="0.7.12">
+<tool id="bwa" name="Map with BWA" version="@VERSION@.1">
   <description>- map short reads (&lt; 100 bp) against reference genome</description>
   <macros>
     <import>read_group_macros.xml</import>
@@ -69,28 +69,7 @@
   <expand macro="stdio" />
   <command>
 <![CDATA[
-    #set $reference_fasta_filename = "localref.fa"
-
-    #if str( $reference_source.reference_source_selector ) == "history":
-        ln -s "${reference_source.ref_file}" "${reference_fasta_filename}" &&
-
-        ## The following shell commands decide which of the BWA indexing algorithms (IS or BWTSW) will be run
-        ## depending on the size of the input FASTA dataset
-        ( size=`stat -c %s "${reference_source.ref_file}" 2>/dev/null`; ## Linux
-          if [ $? -ne 0 ]; then
-              size=\$(stat -f %z "${reference_source.ref_file}"); ## OSX
-          fi &&
-          if [ "\$size" -lt 2000000000 ]; then
-              echo "Reference genome size is \$size bytes, generating BWA index with is algorithm";
-              bwa index -a is "${reference_fasta_filename}";
-          else
-              echo "Reference genome size is \$size bytes, generating BWA index with bwtsw algorithm";
-              bwa index -a bwtsw "${reference_fasta_filename}";
-          fi
-        ) &&
-    #else:
-        #set $reference_fasta_filename = str( $reference_source.ref_file.fields.path )
-    #end if
+    @set_reference_fasta_filename@
 
     ## setup vars for rg handling...
     @define_read_group_helpers@
@@ -246,25 +225,7 @@
   </command>
 
   <inputs>
-    
-    <conditional name="reference_source">
-      <param name="reference_source_selector" type="select" label="Will you select a reference genome from your history or use a built-in index?" help="Built-ins were indexed using default options. See `Indexes` section of help below">
-        <option value="cached">Use a built-in genome index</option>
-        <option value="history">Use a genome from history and build index</option>
-      </param>
-      <when value="cached">
-        <param name="ref_file" type="select" label="Using reference genome" help="Select genome from the list">
-          <options from_data_table="bwa_mem_indexes">
-            <filter type="sort_by" column="2" />
-            <validator type="no_options" message="No indexes are available" />
-          </options>
-          <validator type="no_options" message="A built-in reference genome is not available for the build associated with the selected input file"/>
-        </param>
-      </when>
-      <when value="history">
-        <param name="ref_file" type="data" format="fasta" label="Use the following dataset as the reference sequence" help="You can upload a FASTA sequence to the history and use it as reference" />
-      </when>
-    </conditional>
+    <expand macro="reference_source_conditional" />
     <conditional name="input_type">
       <param name="input_type_selector" type="select" label="Select input type" help="Select between fastq and bam datasets and between paired and single end data">
         <option value="paired">Paired fastq</option>

--- a/tools/bwa/bwa_macros.xml
+++ b/tools/bwa/bwa_macros.xml
@@ -1,5 +1,8 @@
 <macros>
   <import>read_group_macros.xml</import>
+
+  <token name="@VERSION@">0.7.12</token>
+
   <token name="@set_rg_string@">
       #set $rg_string = "@RG\\tID:" + str($rg_id)
       #set $rg_string += $format_read_group("\\tSM:", $rg_sm)
@@ -15,9 +18,23 @@
       #set $rg_string += $format_read_group("\\tPU:", $rg_pu)
   </token>
 
+  <token name="@set_reference_fasta_filename@"><![CDATA[
+    #if str( $reference_source.reference_source_selector ) == "history":
+        #set $reference_fasta_filename = "localref.fa"
+        ln -s "${reference_source.ref_file}" "${reference_fasta_filename}" &&
+        bwa index
+        #if str($reference_source.index_a) != 'auto'
+            -a ${reference_source.index_a}
+        #end if
+        "${reference_fasta_filename}" &&
+    #else:
+        #set $reference_fasta_filename = str( $reference_source.ref_file.fields.path )
+    #end if
+  ]]></token>
+
   <xml name="requirements">
     <requirements>
-      <requirement type="package" version="0.7.12">bwa</requirement>
+      <requirement type="package" version="@VERSION@">bwa</requirement>
       <requirement type="package" version="1.2">samtools</requirement>
     </requirements>
   </xml>
@@ -30,6 +47,32 @@
           <regex match="Exception:" />
       </stdio>
   </xml>
+
+  <macro name="reference_source_conditional">
+    <conditional name="reference_source">
+      <param name="reference_source_selector" type="select" label="Will you select a reference genome from your history or use a built-in index?" help="Built-ins were indexed using default options. See `Indexes` section of help below">
+        <option value="cached">Use a built-in genome index</option>
+        <option value="history">Use a genome from history and build index</option>
+      </param>
+      <when value="cached">
+        <param name="ref_file" type="select" label="Using reference genome" help="Select genome from the list">
+          <options from_data_table="bwa_mem_indexes">
+            <filter type="sort_by" column="2" />
+            <validator type="no_options" message="No indexes are available" />
+          </options>
+          <validator type="no_options" message="A built-in reference genome is not available for the build associated with the selected input file"/>
+        </param>
+      </when>
+      <when value="history">
+        <param name="ref_file" type="data" format="fasta" label="Use the following dataset as the reference sequence" help="You can upload a FASTA sequence to the history and use it as reference" />
+        <param name="index_a" type="select" label="Algorithm for constructing the BWT index" help="(-a)">
+          <option value="auto">Auto. Let BWA decide the best algorithm to use</option>
+          <option value="is">IS linear-time algorithm for constructing suffix array. It requires 5.37N memory where N is the size of the database. IS is moderately fast, but does not work with database larger than 2GB</option>
+          <option value="bwtsw">BWT-SW algorithm. This method works also with big genomes</option>
+        </param>
+      </when>
+    </conditional>
+  </macro>
 
   <macro name="dbKeyActionsBwa">
     <expand macro="dbKeyActions">


### PR DESCRIPTION
My users have been bitten again by the failure of BWA indexing when using a big reference genome with long sequences from the history.

```
[bwa_index] Pack FASTA... 26.13 sec
[bwa_index] Construct BWT for the packed sequence...
[is_bwt] Failed to allocate -7621388068 bytes at is.c line 211: Cannot allocate memory
```

With this patch the trick of calculating the genome size is substituted by a new param which let the user choose the indexing algorithm and by defaults let BWA decide which is the best algorithm for the genome, which seems to work better than the genome size criterion.