### PR TITLE
Update vcftools_merge.xml

### DIFF
--- a/tool_collections/vcftools/vcftools_merge/vcftools_merge.xml
+++ b/tool_collections/vcftools/vcftools_merge/vcftools_merge.xml
@@ -7,25 +7,28 @@
     </requirements>
 
     <command>
+    <![CDATA[
         ## Preprocessing for each dataset.
+        #import re
         #set dataset_names = []
         #for $i, $input in enumerate( $input_files ):
+            #set input_name = re.sub('[^\w\-_]', '_', $input.element_identifier)
             ## Sort file.
-            vcf-sort ${input} > ${i}.vcf.sorted ;
+            vcf-sort '${input}' > '${input_name}.vcf.sorted' &&
 
             ## Compress.
-            bgzip ${i}.vcf.sorted ;
+            bgzip '${input_name}.vcf.sorted' &&
 
             ## Index.
-            tabix -p vcf ${i}.vcf.sorted.gz ;
+            tabix -p vcf '${input_name}.vcf.sorted.gz' &&
 
-            #silent dataset_names.append( str($i) + '.vcf.sorted.gz' )
+            #silent dataset_names.append( "'%s.vcf.sorted.gz'" % $input_name )
         #end for
 
         ## Merge.
         vcf-merge
         #echo ' '.join( dataset_names ) # > ${output}
-
+    ]]>
     </command>
     <inputs>
         <param name="input_files" label="Datasets to Merge" type="data" format="vcf" min="2" multiple="True"/>

--- a/tool_collections/vcftools/vcftools_merge/vcftools_merge.xml
+++ b/tool_collections/vcftools/vcftools_merge/vcftools_merge.xml
@@ -1,4 +1,4 @@
-<tool id="vcftools_merge" name="Merge" version="0.1.1">
+<tool id="vcftools_merge" name="Merge" version="0.1.11">
     <description>multiple VCF datasets</description>
 
     <requirements>

--- a/tool_collections/vcftools/vcftools_merge/vcftools_merge.xml
+++ b/tool_collections/vcftools/vcftools_merge/vcftools_merge.xml
@@ -27,7 +27,7 @@
 
         ## Merge.
         vcf-merge
-        #echo ' '.join( dataset_names ) # > ${output}
+        #echo ' '.join( dataset_names ) # > '${output}'
     ]]>
     </command>
     <inputs>


### PR DESCRIPTION
The wrapper is now using the name of vcf input files as column header instead of the number of the file in the history. 
It also deals with the space and special characters in the files to replace them with "_".
Thanks to @nsoranzo and @jmchilton for helping.