### PR TITLE
Explicitly call python in command instead of using the depredated interpreter attribute

### DIFF
--- a/tool_collections/cufflinks/cuffcompare/cuffcompare_wrapper.xml
+++ b/tool_collections/cufflinks/cuffcompare/cuffcompare_wrapper.xml
@@ -6,8 +6,8 @@
       <import>cuff_macros.xml</import>
     </macros>
     <version_command>cuffcompare 2>&amp;1 | head -n 1</version_command>
-    <command interpreter="python">
-        cuffcompare_wrapper.py 
+    <command>
+        python $__tool_directory__/cuffcompare_wrapper.py
             ## Use annotation reference?
             #if $annotation.use_ref_annotation == "Yes":
                 -r $annotation.reference_annotation

--- a/tool_collections/cufflinks/cufflinks/cufflinks_wrapper.xml
+++ b/tool_collections/cufflinks/cufflinks/cufflinks_wrapper.xml
@@ -6,8 +6,8 @@
       <import>cuff_macros.xml</import>
     </macros>
     <version_command>cufflinks 2>&amp;1 | head -n 1</version_command>
-    <command interpreter="python">
-        cufflinks_wrapper.py 
+    <command>
+        python $__tool_directory__/cufflinks_wrapper.py
             --input=$input
             --assembled-isoforms-output=$assembled_isoforms
             --num-threads="\${GALAXY_SLOTS:-4}"

--- a/tool_collections/cufflinks/cuffmerge/cuffmerge_wrapper.xml
+++ b/tool_collections/cufflinks/cuffmerge/cuffmerge_wrapper.xml
@@ -5,8 +5,8 @@
     <macros>
       <import>cuff_macros.xml</import>
     </macros>
-    <command interpreter="python">
-        cuffmerge_wrapper.py
+    <command>
+        python $__tool_directory__/cuffmerge_wrapper.py
             --num-threads="\${GALAXY_SLOTS:-4}"
             
             ## Use annotation reference?


### PR DESCRIPTION
@natefoo on IRC:
> that reminds me, one of the tools that couldn't run on jetstream was due to its use of interpreter (which pulsar doesn't handle) 
> that tool (when I figure out which one it is) should be updated to use `$__tool_directory__`
it was one of the cuff* 
> cuffdiff maybe

This should fix all cufflinks tools.