### PR TITLE
Fixes the missing module 'six' error in issue #389

### DIFF
--- a/tools/fastq_trimmer_by_quality/fastq_trimmer_by_quality.xml
+++ b/tools/fastq_trimmer_by_quality/fastq_trimmer_by_quality.xml
@@ -1,7 +1,8 @@
 <tool id="fastq_quality_trimmer" name="FASTQ Quality Trimmer" version="1.0.0">
   <description>by sliding window</description>
   <requirements>
-    <requirement type="package" version="1.0.0">galaxy_sequence_utils</requirement>
+      <requirement type="package" version="1.0.0">galaxy_sequence_utils</requirement>
+      <requirement type="package" version="1.10.0">six</requirement>
   </requirements>
   <command interpreter="python">fastq_trimmer_by_quality.py '$input_file' '$output_file' -f '${input_file.extension[len( 'fastq' ):]}' -s '$window_size' 
     -t '$step_size' -e '$trim_ends' -a '$aggregation_action' -x '$exclude_count' -c '$score_comparison' -q '$quality_score' 


### PR DESCRIPTION
https://github.com/galaxyproject/tools-devteam/issues/389

This should definetely be tested by someone from iuc/devteam because
conda-env in each job is not importing the modules in galaxy's virtualenv
'.venv'.