### PR TITLE
Add missing macros include to vcfsort

### DIFF
--- a/tool_collections/vcflib/vcfsort/vcfsort.xml
+++ b/tool_collections/vcflib/vcfsort/vcfsort.xml
@@ -1,5 +1,8 @@
 <tool id="vcfsort" name="VCFsort:" version="@WRAPPER_VERSION@.0">
   <description>Sort VCF dataset by coordinate</description>
+  <macros>
+    <import>macros.xml</import>
+  </macros>
   <command>(grep ^"#" "${input1}"; grep -v ^"#" "${input1}" | LC_ALL=C sort -k1,1 -k2,2n -V) > "${out_file1}"</command>
   <inputs>
     <param format="vcf" name="input1" type="data" label="Select VCF dataset"/>


### PR DESCRIPTION
This should take care of the version string issue encountered in #391.