### PR TITLE
Bowtie2 pre-indexed genomes fix, drop TS dependencies

### DIFF
--- a/tools/bowtie2/bowtie2_wrapper.xml
+++ b/tools/bowtie2/bowtie2_wrapper.xml
@@ -16,7 +16,7 @@
             ln -s -f '$reference_genome.own_file' genome.fa &&
             #set index_path = 'genome'
         #else:
-            #set index_path = '$reference_genome.index.fields.path'
+            #set index_path = $reference_genome.index.fields.path
         #end if
 
         ## execute bowtie2

--- a/tools/bowtie2/tool_dependencies.xml
+++ b/tools/bowtie2/tool_dependencies.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0"?>
-<tool_dependency>
-  <package name="bowtie2" version="2.2.6">
-      <repository name="package_bowtie_2_2_6" owner="iuc" />
-    </package>
-    <package name="samtools" version="1.2">
-      <repository name="package_samtools_1_2" owner="iuc" />
-    </package>
-</tool_dependency>


### PR DESCRIPTION
I introduced this with https://github.com/galaxyproject/tools-devteam/pull/426, effectively breaking pre-indexed genomes.