### PR TITLE
Update cuff_macros.xml

### DIFF
--- a/tool_collections/cufflinks/cuff_macros.xml
+++ b/tool_collections/cufflinks/cuff_macros.xml
@@ -66,7 +66,7 @@
   </token>
   <xml name="cufflinks_gtf_inputs">
     <param format="gtf" name="inputs" type="data" label="GTF file(s) produced by Cufflinks" help="" multiple="true" />
-    <repeat name="additional_inputs" title="Additional GTF Inputs (Lists)">
+    <repeat name="additional_inputs" title="Additional GTF Inputs (type Dataset Collection Lists)">
       <param format="gtf" name="additional_inputs" type="data_collection" label="GTF file(s) produced by Cufflinks" help="" />
     </repeat>
   </xml>


### PR DESCRIPTION
For some users, if they are not used to the term "Dataset collection", it can be confusing for example with `Cuffmerge`.
- They expect the same behaviour as `Concatenate datasets` where you add the datasets with a repeat but the input don't show any dataset because it want a dataset collection.
- Moreover, they think that if they select multiple dataset in the first input `multiple="true"`, they think that the tool will be launched in batch mode. Indeed, the `This is a batch mode input field. Separate jobs will be triggered for each dataset selection.` message only appear if you are in a case of batch mode. It should be a message for the `multiple="true"` which say `This is not a batch mode` 😕 


I don't know exactly which term but the idea is to use the term datatset collection somewhere in the label or in the help.