### PR TITLE
Galaxy sequence utils

### DIFF
--- a/tool_collections/galaxy_sequence_utils/fastq_combiner/fastq_combiner.xml
+++ b/tool_collections/galaxy_sequence_utils/fastq_combiner/fastq_combiner.xml
@@ -1,7 +1,7 @@
 <tool id="fastq_combiner" name="Combine FASTA and QUAL" version="1.0.1">
   <description>into FASTQ</description>
   <requirements>
-    <requirement type="package" version="1.0.0">galaxy_sequence_utils</requirement>
+    <requirement type="package" version="1.0.1">galaxy_sequence_utils</requirement>
   </requirements>
   <command interpreter="python">fastq_combiner.py '$fasta_file' '${fasta_file.extension}' '$qual_file' '${qual_file.extension}' '$output_file' '$force_quality_encoding'</command>
   <inputs>

--- a/tool_collections/galaxy_sequence_utils/fastq_combiner/fastq_combiner.xml
+++ b/tool_collections/galaxy_sequence_utils/fastq_combiner/fastq_combiner.xml
@@ -1,4 +1,4 @@
-<tool id="fastq_combiner" name="Combine FASTA and QUAL" version="1.0.1">
+<tool id="fastq_combiner" name="Combine FASTA and QUAL" version="1.0.2">
   <description>into FASTQ</description>
   <requirements>
     <requirement type="package" version="1.0.1">galaxy_sequence_utils</requirement>

--- a/tool_collections/galaxy_sequence_utils/fastq_filter/fastq_filter.xml
+++ b/tool_collections/galaxy_sequence_utils/fastq_filter/fastq_filter.xml
@@ -1,7 +1,7 @@
 <tool id="fastq_filter" name="Filter FASTQ" version="1.0.0">
   <description>reads by quality score and length</description>
   <requirements>
-    <requirement type="package" version="1.0.0">galaxy_sequence_utils</requirement>
+    <requirement type="package" version="1.0.1">galaxy_sequence_utils</requirement>
   </requirements>
   <command interpreter="python">fastq_filter.py $input_file $fastq_filter_file $output_file $output_file.files_path '${input_file.extension[len( 'fastq' ):]}'</command>
   <inputs>

--- a/tool_collections/galaxy_sequence_utils/fastq_filter/fastq_filter.xml
+++ b/tool_collections/galaxy_sequence_utils/fastq_filter/fastq_filter.xml
@@ -1,4 +1,4 @@
-<tool id="fastq_filter" name="Filter FASTQ" version="1.0.0">
+<tool id="fastq_filter" name="Filter FASTQ" version="1.0.1">
   <description>reads by quality score and length</description>
   <requirements>
     <requirement type="package" version="1.0.1">galaxy_sequence_utils</requirement>

--- a/tool_collections/galaxy_sequence_utils/fastq_groomer/fastq_groomer.xml
+++ b/tool_collections/galaxy_sequence_utils/fastq_groomer/fastq_groomer.xml
@@ -1,7 +1,7 @@
 <tool id="fastq_groomer" name="FASTQ Groomer" version="1.0.4">
   <description>convert between various FASTQ quality formats</description>
   <requirements>
-    <requirement type="package" version="1.0.0">galaxy_sequence_utils</requirement>
+    <requirement type="package" version="1.0.1">galaxy_sequence_utils</requirement>
   </requirements>
   <command interpreter="python">fastq_groomer.py '$input_file' '$input_type' '$output_file'
 #if str( $options_type['options_type_selector'] ) == 'basic':

--- a/tool_collections/galaxy_sequence_utils/fastq_groomer/fastq_groomer.xml
+++ b/tool_collections/galaxy_sequence_utils/fastq_groomer/fastq_groomer.xml
@@ -1,4 +1,4 @@
-<tool id="fastq_groomer" name="FASTQ Groomer" version="1.0.4">
+<tool id="fastq_groomer" name="FASTQ Groomer" version="1.0.5">
   <description>convert between various FASTQ quality formats</description>
   <requirements>
     <requirement type="package" version="1.0.1">galaxy_sequence_utils</requirement>

--- a/tool_collections/galaxy_sequence_utils/fastq_masker_by_quality/fastq_masker_by_quality.xml
+++ b/tool_collections/galaxy_sequence_utils/fastq_masker_by_quality/fastq_masker_by_quality.xml
@@ -1,7 +1,7 @@
 <tool id="fastq_masker_by_quality" name="FASTQ Masker" version="1.0.0">
   <description>by quality score</description>
   <requirements>
-    <requirement type="package" version="1.0.0">galaxy_sequence_utils</requirement>
+    <requirement type="package" version="1.0.1">galaxy_sequence_utils</requirement>
   </requirements>
   <command interpreter="python">fastq_masker_by_quality.py '$input_file' '$output_file' -f '${input_file.extension[len( 'fastq' ):]}' -s '${quality_score}' -c '${score_comparison}'
       #if $mask_type.value == 'lowercase'

--- a/tool_collections/galaxy_sequence_utils/fastq_masker_by_quality/fastq_masker_by_quality.xml
+++ b/tool_collections/galaxy_sequence_utils/fastq_masker_by_quality/fastq_masker_by_quality.xml
@@ -1,4 +1,4 @@
-<tool id="fastq_masker_by_quality" name="FASTQ Masker" version="1.0.0">
+<tool id="fastq_masker_by_quality" name="FASTQ Masker" version="1.0.1">
   <description>by quality score</description>
   <requirements>
     <requirement type="package" version="1.0.1">galaxy_sequence_utils</requirement>

--- a/tool_collections/galaxy_sequence_utils/fastq_paired_end_deinterlacer/fastq_paired_end_deinterlacer.xml
+++ b/tool_collections/galaxy_sequence_utils/fastq_paired_end_deinterlacer/fastq_paired_end_deinterlacer.xml
@@ -1,7 +1,7 @@
 <tool id="fastq_paired_end_deinterlacer" name="FASTQ de-interlacer" version="1.1">
   <description>on paired end reads</description>
   <requirements>
-    <requirement type="package" version="1.0.0">galaxy_sequence_utils</requirement>
+    <requirement type="package" version="1.0.1">galaxy_sequence_utils</requirement>
   </requirements>
   <command interpreter="python">fastq_paired_end_deinterlacer.py '$input_file' '${input_file.extension[len( 'fastq' ):]}' '$output1_pairs_file' '$output2_pairs_file' '$output1_singles_file' '$output2_singles_file'</command>
   <inputs>

--- a/tool_collections/galaxy_sequence_utils/fastq_paired_end_deinterlacer/fastq_paired_end_deinterlacer.xml
+++ b/tool_collections/galaxy_sequence_utils/fastq_paired_end_deinterlacer/fastq_paired_end_deinterlacer.xml
@@ -1,4 +1,4 @@
-<tool id="fastq_paired_end_deinterlacer" name="FASTQ de-interlacer" version="1.1">
+<tool id="fastq_paired_end_deinterlacer" name="FASTQ de-interlacer" version="1.1.1">
   <description>on paired end reads</description>
   <requirements>
     <requirement type="package" version="1.0.1">galaxy_sequence_utils</requirement>

--- a/tool_collections/galaxy_sequence_utils/fastq_paired_end_splitter/fastq_paired_end_splitter.xml
+++ b/tool_collections/galaxy_sequence_utils/fastq_paired_end_splitter/fastq_paired_end_splitter.xml
@@ -1,4 +1,4 @@
-<tool id="fastq_paired_end_splitter" name="FASTQ splitter" version="1.0.0">
+<tool id="fastq_paired_end_splitter" name="FASTQ splitter" version="1.0.1">
   <description>on joined paired end reads</description>
   <requirements>
     <requirement type="package" version="1.0.1">galaxy_sequence_utils</requirement>

--- a/tool_collections/galaxy_sequence_utils/fastq_paired_end_splitter/fastq_paired_end_splitter.xml
+++ b/tool_collections/galaxy_sequence_utils/fastq_paired_end_splitter/fastq_paired_end_splitter.xml
@@ -1,7 +1,7 @@
 <tool id="fastq_paired_end_splitter" name="FASTQ splitter" version="1.0.0">
   <description>on joined paired end reads</description>
   <requirements>
-    <requirement type="package" version="1.0.0">galaxy_sequence_utils</requirement>
+    <requirement type="package" version="1.0.1">galaxy_sequence_utils</requirement>
   </requirements>
   <command interpreter="python">fastq_paired_end_splitter.py '$input1_file' '${input1_file.extension[len( 'fastq' ):]}' '$output1_file' '$output2_file'</command>
   <inputs>

--- a/tool_collections/galaxy_sequence_utils/fastq_stats/fastq_stats.xml
+++ b/tool_collections/galaxy_sequence_utils/fastq_stats/fastq_stats.xml
@@ -1,7 +1,7 @@
 <tool id="fastq_stats" name="FASTQ Summary Statistics" version="1.0.0">
   <description>by column</description>
   <requirements>
-    <requirement type="package" version="1.0.0">galaxy_sequence_utils</requirement>
+    <requirement type="package" version="1.0.1">galaxy_sequence_utils</requirement>
   </requirements>
   <command interpreter="python">fastq_stats.py '$input_file' '$output_file' '${input_file.extension[len( 'fastq' ):]}'</command>
   <inputs>

--- a/tool_collections/galaxy_sequence_utils/fastq_stats/fastq_stats.xml
+++ b/tool_collections/galaxy_sequence_utils/fastq_stats/fastq_stats.xml
@@ -1,4 +1,4 @@
-<tool id="fastq_stats" name="FASTQ Summary Statistics" version="1.0.0">
+<tool id="fastq_stats" name="FASTQ Summary Statistics" version="1.0.1">
   <description>by column</description>
   <requirements>
     <requirement type="package" version="1.0.1">galaxy_sequence_utils</requirement>

--- a/tool_collections/galaxy_sequence_utils/fastq_to_tabular/fastq_to_tabular.xml
+++ b/tool_collections/galaxy_sequence_utils/fastq_to_tabular/fastq_to_tabular.xml
@@ -1,4 +1,4 @@
-<tool id="fastq_to_tabular" name="FASTQ to Tabular" version="1.1.0">
+<tool id="fastq_to_tabular" name="FASTQ to Tabular" version="1.1.1">
   <description>converter</description>
   <requirements>
     <requirement type="package" version="1.0.1">galaxy_sequence_utils</requirement>

--- a/tool_collections/galaxy_sequence_utils/fastq_to_tabular/fastq_to_tabular.xml
+++ b/tool_collections/galaxy_sequence_utils/fastq_to_tabular/fastq_to_tabular.xml
@@ -1,7 +1,7 @@
 <tool id="fastq_to_tabular" name="FASTQ to Tabular" version="1.1.0">
   <description>converter</description>
   <requirements>
-    <requirement type="package" version="1.0.0">galaxy_sequence_utils</requirement>
+    <requirement type="package" version="1.0.1">galaxy_sequence_utils</requirement>
   </requirements>
   <command interpreter="python">fastq_to_tabular.py '$input_file' '$output_file' $descr_columns '${input_file.extension[len( 'fastq' ):]}'</command>
   <inputs>

--- a/tool_collections/galaxy_sequence_utils/fastq_trimmer/fastq_trimmer.xml
+++ b/tool_collections/galaxy_sequence_utils/fastq_trimmer/fastq_trimmer.xml
@@ -1,4 +1,4 @@
-<tool id="fastq_trimmer" name="FASTQ Trimmer" version="1.0.1">
+<tool id="fastq_trimmer" name="FASTQ Trimmer" version="1.0.2">
   <description>by column</description>
   <requirements>
     <requirement type="package" version="1.0.1">galaxy_sequence_utils</requirement>

--- a/tool_collections/galaxy_sequence_utils/fastq_trimmer/fastq_trimmer.xml
+++ b/tool_collections/galaxy_sequence_utils/fastq_trimmer/fastq_trimmer.xml
@@ -1,7 +1,7 @@
 <tool id="fastq_trimmer" name="FASTQ Trimmer" version="1.0.1">
   <description>by column</description>
   <requirements>
-    <requirement type="package" version="1.0.0">galaxy_sequence_utils</requirement>
+    <requirement type="package" version="1.0.1">galaxy_sequence_utils</requirement>
   </requirements>
   <command interpreter="python">fastq_trimmer.py '$input_file' '$output_file' '${offset_type['left_column_offset']}' '${offset_type['right_column_offset']}' '${offset_type['base_offset_type']}' '${input_file.extension[len( 'fastq' ):]}' '$keep_zero_length'</command>
   <inputs>

--- a/tool_collections/galaxy_sequence_utils/fastqtofasta/fastq_to_fasta.xml
+++ b/tool_collections/galaxy_sequence_utils/fastqtofasta/fastq_to_fasta.xml
@@ -1,4 +1,4 @@
-<tool id="fastq_to_fasta_python" name="FASTQ to FASTA" version="1.0.0">
+<tool id="fastq_to_fasta_python" name="FASTQ to FASTA" version="1.0.1">
   <description>converter</description>
   <requirements>
     <requirement type="package" version="1.0.1">galaxy_sequence_utils</requirement>

--- a/tool_collections/galaxy_sequence_utils/fastqtofasta/fastq_to_fasta.xml
+++ b/tool_collections/galaxy_sequence_utils/fastqtofasta/fastq_to_fasta.xml
@@ -1,7 +1,7 @@
 <tool id="fastq_to_fasta_python" name="FASTQ to FASTA" version="1.0.0">
   <description>converter</description>
   <requirements>
-    <requirement type="package" version="1.0.0">galaxy_sequence_utils</requirement>
+    <requirement type="package" version="1.0.1">galaxy_sequence_utils</requirement>
   </requirements>
   <command interpreter="python">fastq_to_fasta.py '$input_file' '$output_file' '${input_file.extension[len( 'fastq' ):]}'</command>
   <inputs>

--- a/tool_collections/galaxy_sequence_utils/tabular_to_fastq/tabular_to_fastq.xml
+++ b/tool_collections/galaxy_sequence_utils/tabular_to_fastq/tabular_to_fastq.xml
@@ -1,4 +1,4 @@
-<tool id="tabular_to_fastq" name="Tabular to FASTQ" version="1.0.0">
+<tool id="tabular_to_fastq" name="Tabular to FASTQ" version="1.0.1">
   <description>converter</description>
   <requirements>
     <requirement type="package" version="1.0.1">galaxy_sequence_utils</requirement>

--- a/tool_collections/galaxy_sequence_utils/tabular_to_fastq/tabular_to_fastq.xml
+++ b/tool_collections/galaxy_sequence_utils/tabular_to_fastq/tabular_to_fastq.xml
@@ -1,7 +1,7 @@
 <tool id="tabular_to_fastq" name="Tabular to FASTQ" version="1.0.0">
   <description>converter</description>
   <requirements>
-    <requirement type="package" version="1.0.0">galaxy_sequence_utils</requirement>
+    <requirement type="package" version="1.0.1">galaxy_sequence_utils</requirement>
   </requirements>
   <command interpreter="python">tabular_to_fastq.py '$input_file' '$output_file' '$identifier' '$sequence' '$quality'</command>
   <inputs>


### PR DESCRIPTION
Default Galaxy tools from tools-devteam/tool_collections/galaxy_sequence_utils are not working since 'galaxy_sequence_utils-1.0.0' doesn't exist as conda recipe. 