### PR TITLE
samtool_filter2: fix support for multiple region filter

### DIFF
--- a/tools/samtool_filter2/samtool_filter2.xml
+++ b/tools/samtool_filter2/samtool_filter2.xml
@@ -59,7 +59,9 @@ samtools view $possibly_select_inverse '$output1' $header
   #end if
   $input
   #if str($regions).strip() and $input1.is_of_type('bam')
-    '$regions'
+    #for region in str($regions).split(' '):
+      '$region'
+    #end for
   #end if
   ## need to redirect stderr message so galaxy does not think this failed
   2>&1

--- a/tools/samtool_filter2/samtool_filter2.xml
+++ b/tools/samtool_filter2/samtool_filter2.xml
@@ -59,7 +59,7 @@ samtools view $possibly_select_inverse '$output1' $header
   #end if
   $input
   #if str($regions).strip() and $input1.is_of_type('bam')
-    #for region in str($regions).split(' '):
+    #for region in str($regions).split():
       '$region'
     #end for
   #end if


### PR DESCRIPTION
This fixes an issue when providing multiple regions divided by whitespace as written in the help. It would cause the tool to write in stdout a message e.g.: 
``[main_samview] region "chr1 chr2" specifies an unknown reference name. Continue anyway.``

as the cmd would read:
``samtools view -o '/galaxy/database/files/001/dataset_1885.dat' -h   -b  input.bam 'chr1 chr2' 2>&1``

Instead of:

``
samtools view -o '/galaxy/database/files/001/dataset_1888.dat' -h   -b  input.bam 'chr1' 'chr2' 2>&1
``