### PR TITLE
bwa: added a regular expression to stdio

### DIFF
--- a/legacy/bwa/bwa_macros.xml
+++ b/legacy/bwa/bwa_macros.xml
@@ -44,7 +44,8 @@
           <exit_code range="1:" />
           <exit_code range=":-1" />
           <regex match="Error:" />
-          <regex match="Exception:" />
+	  <regex match="Exception:" />
+	  <regex match="[bns_restore_core] Parse error reading" />
       </stdio>
   </xml>
 


### PR DESCRIPTION
This happens when unexpected input is provided. For instance a fa.tar file is used (I also read that spaces in the sequence may cause this message).