### PR TITLE
[WIP] Add fix-id option for inconsistent identifiers

### DIFF
--- a/tool_collections/galaxy_sequence_utils/fastq_groomer/fastq_groomer.xml
+++ b/tool_collections/galaxy_sequence_utils/fastq_groomer/fastq_groomer.xml
@@ -1,7 +1,7 @@
-<tool id="fastq_groomer" name="FASTQ Groomer" version="1.1.1">
+<tool id="fastq_groomer" name="FASTQ Groomer" version="1.2.0">
     <description>convert between various FASTQ quality formats</description>
     <requirements>
-        <requirement type="package" version="1.1.1">galaxy_sequence_utils</requirement>
+        <requirement type="package" version="1.2.0">galaxy_sequence_utils</requirement>
     </requirements>
     <command><![CDATA[
 gx-fastq-groomer '$input_file'
@@ -21,7 +21,7 @@ $input_type$suffix '$output_file'
     #end if
     ascii summarize_input
 #else:
-    ${options_type.output_type} ${options_type.force_quality_encoding} ${options_type.summarize_input}
+    ${options_type.output_type} ${options_type.force_quality_encoding} ${options_type.summarize_input} ${options_type.fix_id}
 #end if
     ]]></command>
     <inputs>
@@ -62,6 +62,9 @@ $input_type$suffix '$output_file'
                     <option value="summarize_input" selected="true">Summarize Input</option>
                     <option value="dont_summarize_input">Do not Summarize Input (faster)</option>
                 </param>
+                <param name="fix_id" type="boolean" label="Fix inconsistent identifiers" 
+                    truevalue="--fix-id" falsevalue="--no-fix-id" checked="true">
+                </param>
             </when>
         </conditional>
     </inputs>
@@ -85,6 +88,28 @@ $input_type$suffix '$output_file'
         </data>
     </outputs>
     <tests>
+        <!-- Test fix-id by default -->
+        <test>
+            <param name="input_file" value="fastq_invalid-line3" ftype="fastq" />
+            <param name="input_type" value="sanger" />
+            <param name="options_type_selector" value="basic" />
+            <output name="output_file" file="fastq_invalid-line3_fixed" />
+        </test>
+        <!-- Test fix-id by setting the option -->
+        <test>
+            <param name="input_file" value="fastq_invalid-line3" ftype="fastq" />
+            <param name="input_type" value="sanger" />
+            <param name="options_type_selector" value="advanced" />
+            <param name="fix_id" value="--fix-id" />
+            <output name="output_file" file="fastq_invalid-line3_fixed" />
+        </test>
+        <!-- Test fix-id / option not set; expect failure -->
+        <test expect_failure="true">
+            <param name="input_file" value="fastq_invalid-line3" ftype="fastq" />
+            <param name="input_type" value="sanger" />
+            <param name="options_type_selector" value="advanced" />
+            <param name="fix_id" value="--no-fix-id" />
+        </test>
         <!-- These tests include test files adapted from supplemental material in Cock PJ, Fields CJ, Goto N, Heuer ML, Rice PM. The Sanger FASTQ file format for sequences with quality scores, and the Solexa/Illumina FASTQ variants. Nucleic Acids Res. 2009 Dec 16. -->
         <!-- Test basic options -->
         <test>
@@ -369,7 +394,7 @@ $input_type$suffix '$output_file'
 
 This tool offers several conversions options relating to the FASTQ format.
 
-When using *Basic* options, the output will be *sanger* formatted or *cssanger* formatted (when the input is Color Space Sanger).
+When using *Basic* options, the output will be *sanger* formatted or *cssanger* formatted (when the input is Color Space Sanger). Inconsistent identifiers are fixed by default.
 
 When converting, if a quality score falls outside of the target score range, it will be coerced to the closest available value (i.e. the minimum or maximum).
 

--- a/tool_collections/galaxy_sequence_utils/fastq_groomer/test-data/fastq_invalid-line3
+++ b/tool_collections/galaxy_sequence_utils/fastq_groomer/test-data/fastq_invalid-line3
@@ -1,0 +1,8 @@
+@FAKE-1
+ACGTACGTAC
++invalid line
+!##$%&&()*
+@FAKE-2
+CATGCATGCA
++
+~}|{zyxwvu

--- a/tool_collections/galaxy_sequence_utils/fastq_groomer/test-data/fastq_invalid-line3_fixed
+++ b/tool_collections/galaxy_sequence_utils/fastq_groomer/test-data/fastq_invalid-line3_fixed
@@ -1,0 +1,8 @@
+@FAKE-1
+ACGTACGTAC
++
+!##$%&&()*
+@FAKE-2
+CATGCATGCA
++
+~}|{zyxwvu


### PR DESCRIPTION
Addresses this: https://github.com/galaxyproject/galaxy-hub/issues/216#issuecomment-488310228

Option set by default. Unsetting the option will cause a
fastqFormatError to be raised on faulty data files.

Added relevant tests and test data.

Requires galaxy_sequence_utilities 1.2.0.

@jmchilton @jennaj please take a look (unlike the sequence_utils code, I'm somewhat concerned about this tool wrapper: the tests pass, and I've tested it manually too; but it's my first attempt at modifying a wrapper, so I cannot be sure I got it all right.) Thanks!