### PR TITLE
Convert bytes to string for for stderr output in unified_genotyper.py

### DIFF
--- a/tool_collections/gatk/unified_genotyper/gatk_wrapper.py
+++ b/tool_collections/gatk/unified_genotyper/gatk_wrapper.py
@@ -112,7 +112,7 @@ def __main__():
     while True:
         chunk = stderr.read( CHUNK_SIZE )
         if chunk:
-            stderr_target.write( chunk )
+            stderr_target.write( chunk.decode('utf-8') )
         else:
             break
     stderr.close()


### PR DESCRIPTION
A naive fix for

Traceback (most recent call last):

  File "toolshed.g2.bx.psu.edu/repos/devteam/unified_genotyper/66dd4d4c1743/unified_genotyper/gatk_wrapper.py", line 126, in <module>

    if __name__=="__main__": __main__()

  File "toolshed.g2.bx.psu.edu/repos/devteam/unified_genotyper/66dd4d4c1743/unified_genotyper/gatk_wrapper.py", line 115, in __main__

    stderr_target.write( chunk )

TypeError: write() argument must be str, not bytes