### PR TITLE
Some cosmetic changes to mergeCols

### DIFF
--- a/.tt_skip
+++ b/.tt_skip
@@ -56,7 +56,6 @@ tools/maf_cpg_filter
 tools/mapping_to_ucsc
 tools/megablast_wrapper
 tools/megablast_xml_parser
-tools/merge_cols
 tools/microsatellite_birthdeath
 tools/microsats_alignment_level
 tools/microsats_mutability

--- a/tools/merge_cols/mergeCols.py
+++ b/tools/merge_cols/mergeCols.py
@@ -2,31 +2,25 @@ import sys
 
 
 def __main__():
-    try:
-        infile = open(sys.argv[1], 'r')
-        outfile = open(sys.argv[2], 'w')
-    except Exception:
-        sys.exit('Cannot open or create a file\n')
-
     if len(sys.argv) < 4:
         sys.exit('No columns to merge\n')
     else:
         cols = sys.argv[3:]
 
-    skipped_lines = 0
+    with open(sys.argv[1], 'r') as infile, open(sys.argv[2], 'w') as outfile:
+        skipped_lines = 0
+        for line in infile:
+            line = line.rstrip('\r\n')
+            if line and not line.startswith('#'):
+                fields = line.split('\t')
+                line += '\t'
+                for col in cols:
+                    try:
+                        line += fields[int(col) - 1]
+                    except Exception:
+                        skipped_lines += 1
 
-    for line in infile:
-        line = line.rstrip('\r\n')
-        if line and not line.startswith('#'):
-            fields = line.split('\t')
-            line += '\t'
-            for col in cols:
-                try:
-                    line += fields[int(col) - 1]
-                except Exception:
-                    skipped_lines += 1
-
-            print(line, file=outfile)
+            outfile.write("{}\n".format(line))
 
     if skipped_lines > 0:
         print('Skipped %d invalid lines' % skipped_lines)

--- a/tools/merge_cols/mergeCols.xml
+++ b/tools/merge_cols/mergeCols.xml
@@ -1,18 +1,18 @@
-<tool id="mergeCols1" name="Merge Columns" version="1.0.2">
+<tool id="mergeCols1" name="Merge Columns" version="1.0.3" profile="16.04">
   <description>together</description>
   <requirements>
     <requirement type="package" version="3.7">python</requirement>
   </requirements>
-  <command interpreter="python">
-   mergeCols.py 
-      "${input1}"
-      "${out_file1}"
-      "${col1}"
-      "${col2}"
-      #for $col in $columns
-        ${col.datacol}
-      #end for
-  </command>
+  <command><![CDATA[
+python '$__tool_directory__/mergeCols.py'
+"${input1}"
+"${out_file1}"
+"${col1}"
+"${col2}"
+#for $col in $columns
+  ${col.datacol}
+#end for
+  ]]></command>
   <inputs>
     <param format="tabular" name="input1" type="data" label="Select data" help="Dataset missing? See TIP below."/>
     <param name="col1" label="Merge column" type="data_column" data_ref="input1" />


### PR DESCRIPTION
I set out to fix what @yvanlebras reported on gitter:
```
There is an issue regarding the "Merge Columns" tool https://ecology.usegalaxy.eu/root?tool_id=toolshed.g2.bx.psu.edu/repos/devteam/merge_cols/mergeCols1/1.0.2 . Using 1.0.2 version, all the table is transformed as a one line file. Using 1.0.1 version https://ecology.usegalaxy.eu/root?tool_id=toolshed.g2.bx.psu.edu/repos/devteam/merge_cols/mergeCols1/1.0.1 is ok
history where you can look at this issue (dataset 14 with version 1.0.2, dataset 15 with 1.0.1): https://ecology.usegalaxy.eu/u/ylebras/h/test-training-session
```

I thought the issue was with `print(line, file=outfile)` not adding newlines,
but `\n` is actually the default end character. I can't reproduce Yvan's issue,
but might be a good idea to use `outfile.write()` with explicit newlines, soooo
... maybe let's try this, unless someone can spot what is wrong with Yvan's
example.