### PR TITLE
Update exception handling in gi2taxonomy to be py3-compatible.

### DIFF
--- a/tool_collections/taxonomy/gi2taxonomy/gi2taxonomy.py
+++ b/tool_collections/taxonomy/gi2taxonomy/gi2taxonomy.py
@@ -33,7 +33,7 @@ def gi_name_to_sorted_list(file_name, gi_col, name_col):
         except:
             print >>sys.stderr, 'Non numeric GI field...skipping'
             
-    except Exception, e:
+    except Exception as e:
         stop_err('%s\n' % e)
     F.close()
     result.sort()
@@ -75,7 +75,7 @@ def collapse_repeating_gis( L ):
             gi.append( item[1] )
             i += 1
             
-    except Exception, e:
+    except Exception as e:
         stop_err('%s\n' % e)
         
     prev_L = []
@@ -170,5 +170,5 @@ try:
     retcode = subprocess.call( tb_cmd, shell=True )
     if retcode < 0:
         print >>sys.stderr, "Execution of taxBuilder terminated by signal", -retcode
-except OSError, e:
+except OSError as e:
     print >>sys.stderr, "Execution of taxBuilder2tree failed:", e

--- a/tool_collections/taxonomy/gi2taxonomy/gi2taxonomy.xml
+++ b/tool_collections/taxonomy/gi2taxonomy/gi2taxonomy.xml
@@ -1,4 +1,4 @@
-<tool id="Fetch Taxonomic Ranks" name="Fetch taxonomic representation" version="1.1.0">
+<tool id="Fetch Taxonomic Ranks" name="Fetch taxonomic representation" version="1.1.1">
   <description></description>
     <requirements>
         <requirement type="package" version="1.0.0">taxonomy</requirement>


### PR DESCRIPTION
The syntax `except Exception, e` was deprecated in python 3.

Reported at https://help.galaxyproject.org/t/error-with-fetch-taxonomic-representation/5145