### PR TITLE
sam_bitwise_flag_filter - fix indent

### DIFF
--- a/.tt_skip
+++ b/.tt_skip
@@ -70,7 +70,6 @@ tools/quality_filter
 tools/rcve
 tools/rmap
 tools/rmapq
-tools/sam_bitwise_flag_filter
 tools/sam_merge
 tools/short_reads_figure_high_quality_length
 tools/short_reads_figure_score

--- a/tools/sam_bitwise_flag_filter/sam_bitwise_flag_filter.py
+++ b/tools/sam_bitwise_flag_filter/sam_bitwise_flag_filter.py
@@ -4,11 +4,6 @@ import optparse
 import sys
 
 
-def stop_err(msg):
-    sys.stderr.write(msg)
-    sys.exit()
-
-
 def main():
     usage = """%prog [options]
 

--- a/tools/sam_bitwise_flag_filter/sam_bitwise_flag_filter.py
+++ b/tools/sam_bitwise_flag_filter/sam_bitwise_flag_filter.py
@@ -142,6 +142,9 @@ options (listed below) default to 'None' if omitted
             if valid_line:
                 print(line)
 
+    if options.input_sam:
+        infile.close()
+
 
 if __name__ == "__main__":
     main()

--- a/tools/sam_bitwise_flag_filter/sam_bitwise_flag_filter.py
+++ b/tools/sam_bitwise_flag_filter/sam_bitwise_flag_filter.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
-# Refactored on 11/13/2010 by Kanwei Li
 
-import sys
 import optparse
+import sys
 
-def stop_err( msg ):
-    sys.stderr.write( msg )
+
+def stop_err(msg):
+    sys.stderr.write(msg)
     sys.exit()
+
 
 def main():
     usage = """%prog [options]
@@ -16,99 +17,99 @@ options (listed below) default to 'None' if omitted
     parser = optparse.OptionParser(usage=usage)
 
     parser.add_option(
-        '--0x0001','--is_paired',
-        choices = ( '0','1' ),
+        '--0x0001', '--is_paired',
+        choices=('0', '1'),
         dest='is_paired',
         metavar="<0|1>",
         help='The read is paired in sequencing')
 
     parser.add_option(
-        '--0x0002','--is_proper_pair',
-        choices = ( '0','1' ),
+        '--0x0002', '--is_proper_pair',
+        choices=('0', '1'),
         metavar="<0|1>",
         dest='is_proper_pair',
         help='The read is mapped in a proper pair')
 
     parser.add_option(
-        '--0x0004','--is_unmapped',
-        choices = ( '0','1' ),
+        '--0x0004', '--is_unmapped',
+        choices=('0', '1'),
         metavar="<0|1>",
         dest='is_unmapped',
         help='The query sequence itself is unmapped')
 
     parser.add_option(
-        '--0x0008','--mate_is_unmapped',
-        choices = ( '0','1' ),
+        '--0x0008', '--mate_is_unmapped',
+        choices=('0', '1'),
         metavar="<0|1>",
         dest='mate_is_unmapped',
         help='The mate is unmapped')
 
     parser.add_option(
-        '--0x0010','--query_strand',
+        '--0x0010', '--query_strand',
         dest='query_strand',
         metavar="<0|1>",
-        choices = ( '0','1' ),
-        help='Strand of the query: 0 = forward, 1 = reverse.')
+        choices=('0', '1'),
+        help='Strand of the query: 0=forward, 1=reverse.')
 
     parser.add_option(
-        '--0x0020','--mate_strand',
+        '--0x0020', '--mate_strand',
         dest='mate_strand',
         metavar="<0|1>",
-        choices = ('0','1'),
-        help='Strand of the mate: 0 = forward, 1 = reverse.')
+        choices=('0', '1'),
+        help='Strand of the mate: 0=forward, 1=reverse.')
 
     parser.add_option(
-        '--0x0040','--is_first',
-        choices = ( '0','1' ),
+        '--0x0040', '--is_first',
+        choices=('0', '1'),
         metavar="<0|1>",
         dest='is_first',
         help='The read is the first read in a pair')
 
     parser.add_option(
-        '--0x0080','--is_second',
-        choices = ( '0','1' ),
+        '--0x0080', '--is_second',
+        choices=('0', '1'),
         metavar="<0|1>",
         dest='is_second',
         help='The read is the second read in a pair')
 
     parser.add_option(
-        '--0x0100','--is_not_primary',
-        choices = ( '0','1' ),
+        '--0x0100', '--is_not_primary',
+        choices=('0', '1'),
         metavar="<0|1>",
         dest='is_not_primary',
         help='The alignment for the given read is not primary')
 
     parser.add_option(
-        '--0x0200','--is_bad_quality',
-        choices = ( '0','1' ),
+        '--0x0200', '--is_bad_quality',
+        choices=('0', '1'),
         metavar="<0|1>",
         dest='is_bad_quality',
         help='The read fails platform/vendor quality checks')
 
     parser.add_option(
-        '--0x0400','--is_duplicate',
-        choices = ( '0','1' ),
+        '--0x0400', '--is_duplicate',
+        choices=('0', '1'),
         metavar="<0|1>",
         dest='is_duplicate',
         help='The read is either a PCR or an optical duplicate')
 
     parser.add_option(
-        '-f','--input_sam_file',
+        '-f', '--input_sam_file',
         metavar="INPUT_SAM_FILE",
         dest='input_sam',
-        default = False,
+        default=False,
         help='Name of the SAM file to be filtered. STDIN is default')
 
     parser.add_option(
-        '-c','--flag_column',
+        '-c', '--flag_column',
         dest='flag_col',
-        default = '2',
+        default='2',
         help='Column containing SAM bitwise flag. 1-based')
 
     options, args = parser.parse_args()
 
     if options.input_sam:
-        infile = open ( options.input_sam, 'r')
+        infile = open(options.input_sam, 'r')
     else:
         infile = sys.stdin
 
@@ -126,15 +127,15 @@ options (listed below) default to 'None' if omitted
         options.is_duplicate
     ]
 
-    opt_map = { '0': False, '1': True }
+    opt_map = {'0': False, '1': True}
     used_indices = [(index, opt_map[opt]) for index, opt in enumerate(opt_ary) if opt is not None]
-    flag_col = int( options.flag_col ) - 1
+    flag_col = int(options.flag_col) - 1
 
     for line in infile:
-        line = line.rstrip( '\r\n' )
-        if line and not line.startswith( '#' ) and not line.startswith( '@' ) :
-            fields = line.split( '\t' )
-            flags = int( fields[flag_col] )
+        line = line.rstrip('\r\n')
+        if line and not line.startswith('#') and not line.startswith('@'):
+            fields = line.split('\t')
+            flags = int(fields[flag_col])
 
             valid_line = True
             for index, opt_bool in used_indices:
@@ -145,5 +146,6 @@ options (listed below) default to 'None' if omitted
             if valid_line:
                 print line
 
-if __name__ == "__main__": main()
 
+if __name__ == "__main__":
+    main()

--- a/tools/sam_bitwise_flag_filter/sam_bitwise_flag_filter.py
+++ b/tools/sam_bitwise_flag_filter/sam_bitwise_flag_filter.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 import optparse
 import sys

--- a/tools/sam_bitwise_flag_filter/sam_bitwise_flag_filter.py
+++ b/tools/sam_bitwise_flag_filter/sam_bitwise_flag_filter.py
@@ -10,11 +10,11 @@ def stop_err( msg ):
 
 def main():
     usage = """%prog [options]
-    
+
 options (listed below) default to 'None' if omitted
     """
     parser = optparse.OptionParser(usage=usage)
-    
+
     parser.add_option(
         '--0x0001','--is_paired',
         choices = ( '0','1' ),
@@ -91,14 +91,14 @@ options (listed below) default to 'None' if omitted
         metavar="<0|1>",
         dest='is_duplicate',
         help='The read is either a PCR or an optical duplicate')
-        
+
     parser.add_option(
         '-f','--input_sam_file',
         metavar="INPUT_SAM_FILE",
         dest='input_sam',
         default = False,
         help='Name of the SAM file to be filtered. STDIN is default')
-            
+
     parser.add_option(
         '-c','--flag_column',
         dest='flag_col',
@@ -108,10 +108,10 @@ options (listed below) default to 'None' if omitted
     options, args = parser.parse_args()
 
     if options.input_sam:
-		infile = open ( options.input_sam, 'r')
+        infile = open ( options.input_sam, 'r')
     else:
-    	infile = sys.stdin
-        
+        infile = sys.stdin
+
     opt_ary = [
         options.is_paired,
         options.is_proper_pair,
@@ -125,23 +125,23 @@ options (listed below) default to 'None' if omitted
         options.is_bad_quality,
         options.is_duplicate
     ]
-    
+
     opt_map = { '0': False, '1': True }
     used_indices = [(index, opt_map[opt]) for index, opt in enumerate(opt_ary) if opt is not None]
     flag_col = int( options.flag_col ) - 1
-    
+
     for line in infile:
         line = line.rstrip( '\r\n' )
         if line and not line.startswith( '#' ) and not line.startswith( '@' ) :
             fields = line.split( '\t' )
             flags = int( fields[flag_col] )
-            
+
             valid_line = True
             for index, opt_bool in used_indices:
                 if bool(flags & 0x0001 << index) != opt_bool:
                     valid_line = False
                     break
-                    
+
             if valid_line:
                 print line
 

--- a/tools/sam_bitwise_flag_filter/sam_bitwise_flag_filter.py
+++ b/tools/sam_bitwise_flag_filter/sam_bitwise_flag_filter.py
@@ -144,7 +144,7 @@ options (listed below) default to 'None' if omitted
                     break
 
             if valid_line:
-                print line
+                print(line)
 
 
 if __name__ == "__main__":

--- a/tools/sam_bitwise_flag_filter/sam_bitwise_flag_filter.xml
+++ b/tools/sam_bitwise_flag_filter/sam_bitwise_flag_filter.xml
@@ -1,15 +1,17 @@
-<tool id="sam_bw_filter" name="Filter SAM" version="1.0.0">
+<tool id="sam_bw_filter" name="Filter SAM" version="1.0.0+galaxy1">
   <description>on bitwise flag values</description>
-  <parallelism method="basic"></parallelism>
-  <command interpreter="python">
-    sam_bitwise_flag_filter.py  
-      --input_sam_file=$input1
+  <requirements>
+    <requirement type="package" version="2.7">python</requirement>
+  </requirements>
+  <command detect_errors="aggressive"><![CDATA[
+    python $__tool_directory__/sam_bitwise_flag_filter.py
+      --input_sam_file='$input1'
       --flag_column=2
       #for $bit in $bits
        '${bit.flags}=${bit.states}'
       #end for
-      > $out_file1
-  </command>
+      > '$out_file1'
+  ]]></command>
   <inputs>
     <param format="sam" name="input1" type="data" label="Select dataset to filter"/>
     <repeat name="bits" title="Flag">
@@ -26,10 +28,7 @@
         <option value="--0x0200">The read fails platform/vendor quality checks</option>
         <option value="--0x0400">The read is a PCR or optical duplicate</option>
       </param>
-      <param name="states" type="select" display="radio" label="Set the states for this flag">
-         <option value="0">No</option>
-         <option value="1">Yes</option>
-       </param>
+      <param name="states" type="boolean" checked="false" truevalue="1" falsevalue="0" label="Set the states for this flag" />
     </repeat>
   </inputs>
   <outputs>
@@ -43,31 +42,31 @@
       <output name="out_file1" file="sam_bw_filter_0002-yes.sam" ftype="sam"/>
     </test>
   </tests>
-  <help>
+  <help><![CDATA[
 
 **What it does**
 
 Allows parsing of SAM datasets using bitwise flag (the second column). The bits in the flag are defined as follows::
 
     Bit Info
- ------ --------------------------------------------------------------------------   
- 0x0001 the read is paired in sequencing, no matter whether it is mapped in a pair 
- 0x0002 the read is mapped in a proper pair (depends on the protocol, normally 
-        inferred during alignment) 1 
- 0x0004 the query sequence itself is unmapped 
- 0x0008 the mate is unmapped 1 
- 0x0010 strand of the query (0 for forward; 1 for reverse strand) 
- 0x0020 strand of the mate 1 
+ ------ --------------------------------------------------------------------------
+ 0x0001 the read is paired in sequencing, no matter whether it is mapped in a pair
+ 0x0002 the read is mapped in a proper pair (depends on the protocol, normally
+        inferred during alignment) 1
+ 0x0004 the query sequence itself is unmapped
+ 0x0008 the mate is unmapped 1
+ 0x0010 strand of the query (0 for forward; 1 for reverse strand)
+ 0x0020 strand of the mate 1
  0x0040 the read is the first read in a pair (see below)
- 0x0080 the read is the second read in a pair (see below) 
- 0x0100 the alignment is not primary (a read having split hits may 
-        have multiple primary alignment records) 
- 0x0200 the read fails platform/vendor quality checks 
+ 0x0080 the read is the second read in a pair (see below)
+ 0x0100 the alignment is not primary (a read having split hits may
+        have multiple primary alignment records)
+ 0x0200 the read fails platform/vendor quality checks
  0x0400 the read is either a PCR duplicate or an optical duplicate
 
 Note the following:
 
-- Flag 0x02, 0x08, 0x20, 0x40 and 0x80 are only meaningful when flag 0x01 is present. 
+- Flag 0x02, 0x08, 0x20, 0x40 and 0x80 are only meaningful when flag 0x01 is present.
 - If in a read pair the information on which read is the first in the pair is lost in the upstream analysis, flag 0x01 should be set, while 0x40 and 0x80 should both be zero.
 
 -----
@@ -93,5 +92,6 @@ For more information, please consult the `SAM format description`__.
 .. __: http://www.ncbi.nlm.nih.gov/pubmed/19505943
 
 
-  </help>
+  ]]></help>
+  <citations />
 </tool>

--- a/tools/sam_bitwise_flag_filter/sam_bitwise_flag_filter.xml
+++ b/tools/sam_bitwise_flag_filter/sam_bitwise_flag_filter.xml
@@ -1,10 +1,10 @@
-<tool id="sam_bw_filter" name="Filter SAM" version="1.0.0+galaxy1">
+<tool id="sam_bw_filter" name="Filter SAM" version="1.0.1">
   <description>on bitwise flag values</description>
   <requirements>
     <requirement type="package" version="2.7">python</requirement>
   </requirements>
   <command detect_errors="aggressive"><![CDATA[
-    python $__tool_directory__/sam_bitwise_flag_filter.py
+python '$__tool_directory__/sam_bitwise_flag_filter.py'
       --input_sam_file='$input1'
       --flag_column=2
       #for $bit in $bits


### PR DESCRIPTION
This MR should fix this issue:

```
File "/shared/ifbstor1/galaxy/shed_tools/toolshed.g2.bx.psu.edu/repos/devteam/sam_bitwise_flag_filter/0b2424a404d9/sam_bitwise_flag_filter/sam_bitwise_flag_filter.py", line 111
infile = open ( options.input_sam, 'r')
^
TabError: inconsistent use of tabs and spaces in indentation
```