### PR TITLE
tabular_to_fasta: Strip title_col input, fix flake8 errors

### DIFF
--- a/tools/tabular_to_fasta/tabular_to_fasta.py
+++ b/tools/tabular_to_fasta/tabular_to_fasta.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 """
-Input: fasta, minimal length, maximal length
+Input: fasta, title columns (comma separated), sequence column
 Output: fasta
-Return sequences whose lengths are within the range.
+Return tabular format sequences converted to FASTA
 """
-import os
+import argparse
 import sys
 
 
@@ -13,53 +13,56 @@ def stop_err(msg):
 
 
 def __main__():
-    infile = sys.argv[1]
-    title_col = sys.argv[2]
-    seq_col = sys.argv[3]
-    outfile = sys.argv[4]
+    parser = argparse.ArgumentParser()
+    parser.add_argument('input_file', type=argparse.FileType())
+    parser.add_argument('title_col')
+    parser.add_argument('seq_col')
+    parser.add_argument('output_file', type=argparse.FileType('w'))
+    args = parser.parse_args()
+    title_col = args.title_col
+    seq_col = args.seq_col
 
-    if title_col == None or title_col == 'None' or seq_col == None or seq_col == 'None':
+    if title_col is None or title_col == 'None' or seq_col is None or seq_col == 'None':
         stop_err("Columns not specified.")
     try:
         seq_col = int(seq_col) - 1
-    except:
+    except ValueError:
         stop_err("Invalid Sequence Column: %s." % str(seq_col))
 
-    title_col_list = title_col.split(',')
+    title_col_list = title_col.strip().split(',')
     skipped_lines = 0
     first_invalid_line = 0
     invalid_line = ""
     i = 0
 
-    with open(outfile, 'w') as out:
-        for i, line in enumerate(open(infile)):
-            error = False
-            line = line.rstrip('\r\n')
-            if line and not line.startswith('#'):
-                fields = line.split('\t')
-                fasta_title = []
-                for j in title_col_list:
-                    try:
-                        j = int(j) - 1
-                        fasta_title.append(fields[j])
-                    except:
-                        skipped_lines += 1
-                        if not invalid_line:
-                            first_invalid_line = i + 1
-                            invalid_line = line
-                        error = True
-                        break
-                if not error:
-                    try:
-                        fasta_seq = fields[seq_col]
-                        if fasta_title[0].startswith(">"):
-                            fasta_title[0] = fasta_title[0][1:]
-                        print(">%s\n%s" % ("_".join(fasta_title), fasta_seq), file=out)
-                    except:
-                        skipped_lines += 1
-                        if not invalid_line:
-                            first_invalid_line = i + 1
-                            invalid_line = line
+    for i, line in enumerate(args.input_file):
+        error = False
+        line = line.rstrip('\r\n')
+        if line and not line.startswith('#'):
+            fields = line.split('\t')
+            fasta_title = []
+            for j in title_col_list:
+                try:
+                    j = int(j) - 1
+                    fasta_title.append(fields[j])
+                except ValueError:
+                    skipped_lines += 1
+                    if not invalid_line:
+                        first_invalid_line = i + 1
+                        invalid_line = line
+                    error = True
+                    break
+            if not error:
+                try:
+                    fasta_seq = fields[seq_col]
+                    if fasta_title[0].startswith(">"):
+                        fasta_title[0] = fasta_title[0][1:]
+                    print(">%s\n%s" % ("_".join(fasta_title), fasta_seq), file=args.output_file)
+                except ValueError:
+                    skipped_lines += 1
+                    if not invalid_line:
+                        first_invalid_line = i + 1
+                        invalid_line = line
 
     if skipped_lines > 0:
         print('Data issue: skipped %d blank or invalid lines starting at #%d: "%s"' % (skipped_lines, first_invalid_line, invalid_line))

--- a/tools/tabular_to_fasta/tabular_to_fasta.xml
+++ b/tools/tabular_to_fasta/tabular_to_fasta.xml
@@ -1,4 +1,4 @@
-<tool id="tab2fasta" name="Tabular-to-FASTA" version="1.1.1" profile="16.04">
+<tool id="tab2fasta" name="Tabular-to-FASTA" version="1.1.2" profile="16.04">
     <description>converts tabular file to FASTA format</description>
     <requirements>
         <requirement type="package" version="3.7">python</requirement>


### PR DESCRIPTION
While [this PR](https://github.com/galaxyproject/galaxy/pull/14518) addresses the problem where end-of-lines creep into `data_column` inputs in the workflow editor, for older releases of Galaxy (pre-22.05) this still causes a problem for the tabular_to_fasta tool. This PR fixes that while also fixing flake8 errors and using argparse instead of sys.argv for input (so that if errors with file I/O occur they are more readable).